### PR TITLE
Remove registry from spec

### DIFF
--- a/registry/funcs_test.go
+++ b/registry/funcs_test.go
@@ -121,6 +121,7 @@ func TestLengthFunc(t *testing.T) {
 func TestCheckSingularFuncArgs(t *testing.T) {
 	t.Parallel()
 	r := require.New(t)
+	reg := New()
 
 	for _, tc := range []struct {
 		name      string
@@ -158,8 +159,7 @@ func TestCheckSingularFuncArgs(t *testing.T) {
 		},
 		{
 			name: "logical_function_expr",
-			expr: []spec.FunctionExprArg{newFuncExpr(
-				t, "match",
+			expr: []spec.FunctionExprArg{spec.NewFunctionExpr(reg.Get("match"),
 				[]spec.FunctionExprArg{
 					spec.FilterQuery(
 						spec.Query(true, []*spec.Segment{spec.Child(spec.Name("x"))}),
@@ -220,6 +220,7 @@ func TestCheckSingularFuncArgs(t *testing.T) {
 func TestCheckRegexFuncArgs(t *testing.T) {
 	t.Parallel()
 	r := require.New(t)
+	reg := New()
 
 	for _, tc := range []struct {
 		name string
@@ -276,8 +277,7 @@ func TestCheckRegexFuncArgs(t *testing.T) {
 		{
 			name: "function_expr_1",
 			expr: []spec.FunctionExprArg{
-				newFuncExpr(
-					t, "match",
+				spec.NewFunctionExpr(reg.Get("match"),
 					[]spec.FunctionExprArg{
 						spec.FilterQuery(
 							spec.Query(true, []*spec.Segment{spec.Child(spec.Name("x"))}),
@@ -293,8 +293,7 @@ func TestCheckRegexFuncArgs(t *testing.T) {
 			name: "function_expr_2",
 			expr: []spec.FunctionExprArg{
 				spec.Literal("hi"),
-				newFuncExpr(
-					t, "match",
+				spec.NewFunctionExpr(reg.Get("match"),
 					[]spec.FunctionExprArg{
 						spec.FilterQuery(
 							spec.Query(true, []*spec.Segment{spec.Child(spec.Name("x"))}),

--- a/registry/registry_example_test.go
+++ b/registry/registry_example_test.go
@@ -3,6 +3,7 @@ package registry_test
 import (
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/theory/jsonpath/registry"
 	"github.com/theory/jsonpath/spec"
@@ -38,12 +39,15 @@ func firstFunc(jv []spec.JSONPathValue) spec.JSONPathValue {
 // first node in a list of nodes passed to it.
 func Example() {
 	reg := registry.New()
-	reg.Register(&registry.Function{
-		Name:       "first",
-		ResultType: spec.FuncValue,
-		Validate:   validateFirstArgs,
-		Evaluate:   firstFunc,
-	})
-	fmt.Printf("%v\n", reg.Get("first").ResultType)
+	err := reg.Register(
+		"first",
+		spec.FuncValue,
+		validateFirstArgs,
+		firstFunc,
+	)
+	if err != nil {
+		log.Fatalf("Error %v", err)
+	}
+	fmt.Printf("%v\n", reg.Get("first").ResultType())
 	// Output:FuncValue
 }

--- a/spec/filter.go
+++ b/spec/filter.go
@@ -61,9 +61,10 @@ func (lo LogicalOr) writeTo(buf *strings.Builder) {
 	}
 }
 
-// execute evaluates lo and returns LogicalTrue when it returns true and
-// LogicalFalse when it returns false.
-func (lo LogicalOr) execute(current, root any) JSONPathValue {
+// evaluate evaluates lo and returns LogicalTrue when it returns true and
+// LogicalFalse when it returns false. Defined by the [FunctionExprArg]
+// interface.
+func (lo LogicalOr) evaluate(current, root any) JSONPathValue {
 	return LogicalFrom(lo.testFilter(current, root))
 }
 

--- a/spec/filter_test.go
+++ b/spec/filter_test.go
@@ -179,7 +179,7 @@ func TestLogicalOrExpr(t *testing.T) {
 			orExpr := LogicalOr(tc.expr)
 			a.Equal(FuncLogical, orExpr.ResultType())
 			a.Equal(tc.exp, orExpr.testFilter(tc.current, tc.root))
-			a.Equal(LogicalFrom(tc.exp), orExpr.execute(tc.current, tc.root))
+			a.Equal(LogicalFrom(tc.exp), orExpr.evaluate(tc.current, tc.root))
 			a.Equal(tc.str, bufString(orExpr))
 
 			// Test ParenExpr.

--- a/spec/op_test.go
+++ b/spec/op_test.go
@@ -341,43 +341,43 @@ func TestComparisonExpr(t *testing.T) {
 			name: "func_numbers_eq",
 			left: &FunctionExpr{
 				args: []FunctionExprArg{SingularQuery(true, []Selector{Name("x")})},
-				fn:   registry["length"],
+				fn:   newValueFunc(1),
 			},
 			right: &FunctionExpr{
 				args: []FunctionExprArg{SingularQuery(true, []Selector{Name("y")})},
-				fn:   registry["length"],
+				fn:   newValueFunc(1),
 			},
 			root:   map[string]any{"x": "xx", "y": "yy"},
 			expect: []bool{true, false, false, false, true, true},
-			str:    `length($["x"]) %v length($["y"])`,
+			str:    `__val($["x"]) %v __val($["y"])`,
 		},
 		{
 			name: "func_numbers_lt",
 			left: &FunctionExpr{
 				args: []FunctionExprArg{SingularQuery(true, []Selector{Name("x")})},
-				fn:   registry["length"],
+				fn:   newValueFunc(1),
 			},
 			right: &FunctionExpr{
 				args: []FunctionExprArg{SingularQuery(true, []Selector{Name("y")})},
-				fn:   registry["length"],
+				fn:   newValueFunc(2),
 			},
 			root:   map[string]any{"x": "xx", "y": "yyy"},
 			expect: []bool{false, true, true, false, true, false},
-			str:    `length($["x"]) %v length($["y"])`,
+			str:    `__val($["x"]) %v __val($["y"])`,
 		},
 		{
 			name: "func_strings_gt",
 			left: &FunctionExpr{
 				args: []FunctionExprArg{FilterQuery(Query(false, []*Segment{Child(Name("y"))}))},
-				fn:   registry["value"],
+				fn:   newValueFunc(42),
 			},
 			right: &FunctionExpr{
 				args: []FunctionExprArg{FilterQuery(Query(false, []*Segment{Child(Name("x"))}))},
-				fn:   registry["value"],
+				fn:   newValueFunc(41),
 			},
 			current: map[string]any{"x": "x", "y": "y"},
 			expect:  []bool{false, true, false, true, false, true},
-			str:     `value(@["y"]) %v value(@["x"])`,
+			str:     `__val(@["y"]) %v __val(@["x"])`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/spec/selector_test.go
+++ b/spec/selector_test.go
@@ -199,6 +199,16 @@ func TestSliceBounds(t *testing.T) {
 			},
 		},
 		{
+			name:  "nil_nil_nil",
+			slice: Slice(nil, nil, nil),
+			exp:   json,
+			cases: []lenCase{
+				{10, 0, 10},
+				{3, 0, 3},
+				{99, 0, 99},
+			},
+		},
+		{
 			name:  "3_8_2",
 			slice: Slice(3, 8, 2),
 			exp:   []any{"d", "f"},


### PR DESCRIPTION
This eliminates the global registry object in favor of a (possibly user-created) registry instance. Users need this ability in order to add custom functions without changing the behavior of JSONPath expressions globally.

Replace `spec.Function` with an interface that registry.Function (added in 701cf60) adheres to. Refactor `NewFunctionExpr` to simply create a `FunctionExpr` with that interface and performs no validation.

Instead, teach the parser use a registry.Registry to look up functions and validate arguments. This requires that the parser have a registry instance, so add a `parser` struct that stores both a registry and a lexer, and cease passing the lexer to every parsing function.

While at it, add the `Validator` and `Evaluator` interfaces to the registry package and teach the `Register` method (now an instance method) to return errors rather than panic. Also pass `Function` fields to it rather than a `Function` instance, as it's a cleaner API. Then make the `Function` fields private and add accessor methods to comply with the `spec.Function` interface.

Other bits and bobs:

*   Rename `execute` to `evaluate` to be more consistent.
*   Remove the default function definitions from the spec package, as they now live in the registry package.
*   Add a mock function to properly test function expressions.
*   Add overlooked test case for a nil slice step.* 