### PR TITLE
Add Parser object with custom registry

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -115,10 +115,16 @@ linters-settings:
       - empty
       - stdlib
       - generic
-      - JSONPathValue
-      - FunctionExprArg
+      - spec\.JSONPathValue
+      - spec\.FunctionExprArg
+      - spec\.Selector
+      - spec\.BasicExpr
+      - spec\.CompVal
       # You can specify idiomatic endings for interface
       # - (or|er)$
     # reject-list of interfaces
     # reject:
     #   - github.com\/user\/package\/v4\.Type
+  dupword:
+    ignore:
+      - R.

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -1,4 +1,6 @@
-// Package parser handles parsing RFC 9535 JSONPath queries.
+// Package parser parses RFC 9535 JSONPath queries into parse trees. Most
+// JSONPath users will use package [github.com/theory/jsonpath] instead of
+// this package.
 package parser
 
 import (
@@ -35,10 +37,10 @@ type parser struct {
 
 // Parse parses path, a JSON Path query string, into a PathQuery. Returns a
 // PathParseError on parse failure.
-func Parse(path string) (*spec.PathQuery, error) {
+func Parse(reg *registry.Registry, path string) (*spec.PathQuery, error) {
 	lex := newLexer(path)
 	tok := lex.scan()
-	p := parser{lex, registry.New()}
+	p := parser{lex, reg}
 
 	switch tok.tok {
 	case '$':
@@ -110,8 +112,6 @@ func (p *parser) parseQuery(root bool) (*spec.PathQuery, error) {
 
 // parseNameOrWildcard parses a name or '*' wildcard selector. Returns the
 // parsed Selector.
-//
-//nolint:ireturn
 func parseNameOrWildcard(lex *lexer) (spec.Selector, error) {
 	switch tok := lex.scan(); tok.tok {
 	case identifier:
@@ -356,8 +356,6 @@ func (p *parser) parseLogicalAndExpr() (spec.LogicalAnd, error) {
 // parseBasicExpr parses a [BasicExpr] from lex. A [BasicExpr] may be a
 // parenthesized expression (paren-expr), comparison expression
 // (comparison-expr), or test expression (test-expr).
-//
-//nolint:ireturn
 func (p *parser) parseBasicExpr() (spec.BasicExpr, error) {
 	// Consume blank space.
 	lex := p.lex
@@ -423,8 +421,6 @@ func (p *parser) parseBasicExpr() (spec.BasicExpr, error) {
 // Otherwise it will be a [ComparisonExpr] (comparison-expr), as long as the
 // function call is compared to another expression. Any other configuration
 // returns an error.
-//
-//nolint:ireturn
 func (p *parser) parseFunctionFilterExpr(ident token) (spec.BasicExpr, error) {
 	f, err := p.parseFunction(ident)
 	if err != nil {
@@ -645,8 +641,6 @@ func (p *parser) parseComparableExpr(left spec.CompVal) (*spec.ComparisonExpr, e
 }
 
 // parseComparableVal parses a [CompVal] (comparable) from lex.
-//
-//nolint:ireturn
 func (p *parser) parseComparableVal(tok token) (spec.CompVal, error) {
 	switch tok.tok {
 	case goString, integer, number, boolFalse, boolTrue, jsonNull:

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -16,7 +16,7 @@ func TestParseRoot(t *testing.T) {
 	a := assert.New(t)
 	r := require.New(t)
 
-	q, err := Parse("$")
+	q, err := Parse(registry.New(), "$")
 	r.NoError(err)
 	a.Equal("$", q.String())
 	a.Empty(q.Segments())
@@ -26,6 +26,7 @@ func TestParseSimple(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
 	r := require.New(t)
+	reg := registry.New()
 
 	for _, tc := range []struct {
 		name string
@@ -199,7 +200,7 @@ func TestParseSimple(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			q, err := Parse(tc.path)
+			q, err := Parse(reg, tc.path)
 			if tc.err == "" {
 				r.NoError(err)
 				a.Equal(tc.exp, q)
@@ -856,6 +857,7 @@ func TestParseSelectors(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
 	r := require.New(t)
+	reg := registry.New()
 
 	for _, tc := range []struct {
 		name string
@@ -1289,7 +1291,7 @@ func TestParseSelectors(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			q, err := Parse(tc.path)
+			q, err := Parse(reg, tc.path)
 			if tc.err == "" {
 				r.NoError(err)
 				a.Equal(tc.exp, q)

--- a/path.go
+++ b/path.go
@@ -3,8 +3,12 @@ package jsonpath
 
 import (
 	"github.com/theory/jsonpath/parser"
+	"github.com/theory/jsonpath/registry"
 	"github.com/theory/jsonpath/spec"
 )
+
+// ErrPathParse errors are returned for path parse errors.
+var ErrPathParse = parser.ErrPathParse
 
 // Path represents a [RFC 9535] JSONPath query.
 //
@@ -18,16 +22,16 @@ func New(q *spec.PathQuery) *Path {
 	return &Path{q: q}
 }
 
-// Parse parses path, a JSON Path query string, into a Path. Returns a
-// PathParseError on parse failure.
-//
-//nolint:wrapcheck
+// Parse parses path, a JSONPath query string, into a Path. Returns an
+// ErrPathParse on parse failure.
 func Parse(path string) (*Path, error) {
-	q, err := parser.Parse(path)
-	if err != nil {
-		return nil, err
-	}
-	return New(q), nil
+	return NewParser().Parse(path)
+}
+
+// MustParse parses path into a Path. Panics with an ErrPathParse on parse
+// failure.
+func MustParse(path string) *Path {
+	return NewParser().MustParse(path)
 }
 
 // String returns a string representation of p.
@@ -40,7 +44,57 @@ func (p *Path) Query() *spec.PathQuery {
 	return p.q
 }
 
-// Select executes the p query against input and returns the results.
+// Select returns the values that JSONPath query p selects from input.
 func (p *Path) Select(input any) []any {
 	return p.q.Select(nil, input)
+}
+
+// Parser parses JSONPath strings into [*Path]s.
+type Parser struct {
+	reg *registry.Registry
+}
+
+// Option defines a parser option.
+type Option func(*Parser)
+
+// WithRegistry configures a Parser with a function Registry, which may
+// contain function extensions. See [Parser] for an example.
+func WithRegistry(reg *registry.Registry) Option {
+	return func(p *Parser) { p.reg = reg }
+}
+
+// NewParser creates a new Parser configured by opt.
+func NewParser(opt ...Option) *Parser {
+	p := &Parser{}
+	for _, o := range opt {
+		o(p)
+	}
+
+	if p.reg == nil {
+		p.reg = registry.New()
+	}
+
+	return p
+}
+
+// Parse parses path, a JSON Path query string, into a Path. Returns an
+// ErrPathParse on parse failure.
+//
+//nolint:wrapcheck
+func (c *Parser) Parse(path string) (*Path, error) {
+	q, err := parser.Parse(c.reg, path)
+	if err != nil {
+		return nil, err
+	}
+	return New(q), nil
+}
+
+// MustParse parses path, a JSON Path query string, into a Path. Panics with
+// an ErrPathParse on parse failure.
+func (c *Parser) MustParse(path string) *Path {
+	q, err := parser.Parse(c.reg, path)
+	if err != nil {
+		panic(err)
+	}
+	return New(q)
 }

--- a/path_example_test.go
+++ b/path_example_test.go
@@ -1,0 +1,190 @@
+package jsonpath_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/theory/jsonpath"
+	"github.com/theory/jsonpath/registry"
+	"github.com/theory/jsonpath/spec"
+)
+
+// Select all the authors of the books in a bookstore object.
+func Example() {
+	// Parse a jsonpath query.
+	p, err := jsonpath.Parse(`$.store.book[*].author`)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Select values from unmarshaled JSON input.
+	store := bookstore()
+	result := p.Select(store)
+
+	// Show the result.
+	items, err := json.Marshal(result)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", items)
+
+	// Output: ["Nigel Rees","Evelyn Waugh","Herman Melville","J. R. R. Tolkien"]
+}
+
+// Use the Parser to parse a collection of paths.
+func ExampleParser() {
+	// Create a new parser using the default function registry.
+	parser := jsonpath.NewParser()
+
+	// Parse a list of paths.
+	paths := []*jsonpath.Path{}
+	for _, path := range []string{
+		"$.store.book[*].author",
+		"$..author",
+		"$.store..color",
+		"$..book[2].author",
+		"$..book[2].publisher",
+		"$..book[?@.isbn].title",
+		"$..book[?@.price<10].title",
+	} {
+		p, err := parser.Parse(path)
+		if err != nil {
+			log.Fatal(err)
+		}
+		paths = append(paths, p)
+	}
+
+	// Later, use the paths to select from JSON inputs.
+	store := bookstore()
+	for _, p := range paths {
+		items := p.Select(store)
+		array, err := json.Marshal(items)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Printf("%s\n", array)
+	}
+	// Output:
+	// ["Nigel Rees","Evelyn Waugh","Herman Melville","J. R. R. Tolkien"]
+	// ["Nigel Rees","Evelyn Waugh","Herman Melville","J. R. R. Tolkien"]
+	// ["red"]
+	// ["Herman Melville"]
+	// []
+	// ["Moby Dick","The Lord of the Rings"]
+	// ["Sayings of the Century","Moby Dick"]
+}
+
+// The second use case for the Parser is to provide a [registry.Registry]
+// containing function extensions, as [defined by the standard]. This example
+// creates a function named "first" that returns the first item in a list of
+// nodes.
+//
+// [defined by the standard]: https://www.rfc-editor.org/rfc/rfc9535.html#name-function-extensions
+func ExampleParser_functionExtension() {
+	// Register the first function.
+	reg := registry.New()
+	err := reg.Register(
+		"first",           // name
+		spec.FuncValue,    // returns a single value
+		validateFirstArgs, // parse-time validation defined below
+		firstFunc,         // function defined below
+	)
+	if err != nil {
+		log.Fatalf("Error %v", err)
+	}
+
+	// Create a parser with the registry that contains the extension.
+	parser := jsonpath.NewParser(jsonpath.WithRegistry(reg))
+
+	// Use the function to select lists that start with 6.
+	path, err := parser.Parse("$[? first(@.*) == 6]")
+	if err != nil {
+		log.Fatalf("Error %v", err)
+	}
+
+	// Do any of these arrays start with 6?
+	input := []any{
+		[]any{1, 2, 3, 4, 5},
+		[]any{6, 7, 8, 9},
+		[]any{4, 8, 12},
+	}
+	result := path.Select(input)
+	fmt.Printf("%v\n", result)
+	// Output: [[6 7 8 9]]
+}
+
+// validateFirstArgs validates that a single argument is passed to the first()
+// function, and that it can be converted to [spec.PathNodes], so that first()
+// can return the first node. It's called by the parser.
+func validateFirstArgs(fea []spec.FunctionExprArg) error {
+	if len(fea) != 1 {
+		return fmt.Errorf("expected 1 argument but found %v", len(fea))
+	}
+
+	if !fea[0].ResultType().ConvertsTo(spec.PathNodes) {
+		return errors.New("cannot convert argument to PathNodes")
+	}
+
+	return nil
+}
+
+// firstFunc defines the custom first() JSONPath function. It converts its
+// single argument to a [spec.NodesType] value and returns a [*spec.ValueType]
+// that contains the first node. If there are no nodes it returns nil.
+func firstFunc(jv []spec.JSONPathValue) spec.JSONPathValue {
+	nodes := spec.NodesFrom(jv[0])
+	if len(nodes) == 0 {
+		return nil
+	}
+	return spec.Value(nodes[0])
+}
+
+// bookstore returns an unmarshaled JSON object.
+func bookstore() any {
+	src := []byte(`{
+		"store": {
+		  "book": [
+			{
+			  "category": "reference",
+			  "author": "Nigel Rees",
+			  "title": "Sayings of the Century",
+			  "price": 8.95
+			},
+			{
+			  "category": "fiction",
+			  "author": "Evelyn Waugh",
+			  "title": "Sword of Honour",
+			  "price": 12.99
+			},
+			{
+			  "category": "fiction",
+			  "author": "Herman Melville",
+			  "title": "Moby Dick",
+			  "isbn": "0-553-21311-3",
+			  "price": 8.99
+			},
+			{
+			  "category": "fiction",
+			  "author": "J. R. R. Tolkien",
+			  "title": "The Lord of the Rings",
+			  "isbn": "0-395-19395-8",
+			  "price": 22.99
+			}
+		  ],
+		  "bicycle": {
+			"color": "red",
+			"price": 399
+		  }
+		}
+	  }`)
+
+	// Parse the JSON.
+	var value any
+	if err := json.Unmarshal(src, &value); err != nil {
+		log.Fatal(err)
+	}
+	return value
+}

--- a/registry/registry_example_test.go
+++ b/registry/registry_example_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/theory/jsonpath/spec"
 )
 
+// Create and registry a custom JSONPath expression, first(), that returns the
+// first node in a list of nodes passed to it. See
+// [github.com/theory/jsonpath.Parser] for a more complete example.
+func Example() {
+	reg := registry.New()
+	err := reg.Register(
+		"first",           // function name
+		spec.FuncValue,    // returns a single value
+		validateFirstArgs, // parse-time validation defined below
+		firstFunc,         // function defined below
+	)
+	if err != nil {
+		log.Fatalf("Error %v", err)
+	}
+	fmt.Printf("%v\n", reg.Get("first").ResultType())
+	// Output:FuncValue
+}
+
 // validateFirstArgs validates that a single argument is passed to the first()
 // function, and that it can be converted to [spec.PathNodes], so that first()
 // can return the first node. It's called by the parser.
@@ -33,21 +51,4 @@ func firstFunc(jv []spec.JSONPathValue) spec.JSONPathValue {
 		return nil
 	}
 	return spec.Value(nodes[0])
-}
-
-// Create and registry a custom JSONPath expression, first(), that returns the
-// first node in a list of nodes passed to it.
-func Example() {
-	reg := registry.New()
-	err := reg.Register(
-		"first",
-		spec.FuncValue,
-		validateFirstArgs,
-		firstFunc,
-	)
-	if err != nil {
-		log.Fatalf("Error %v", err)
-	}
-	fmt.Printf("%v\n", reg.Get("first").ResultType())
-	// Output:FuncValue
 }


### PR DESCRIPTION
Add the Parser struct, which just stores a reference to a function registry. Give it `Parse` and `MustParse` methods, which parse paths with the supplied registry. This allows the use of a registry with custom extensions. Update the `Parse` function to delegate to a parser and add a `MustParse` function to do the same but panic instead of returning an error.

Change `parse.Parse` to take a registry as an argument, and teach the Parser to pass one.

Add example tests demonstrating these use cases.

Update the golangci-lint config to allow functions that return interfaces defined by the spec package and to ignore the double `R.` in the `J. R. R. Tolkien" examples.