### PR TITLE
Expand public spec APIs, fix FilterSelector string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ All notable changes to this project will be documented in this file. It uses the
   [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
     "Semantic Versioning 2.0.0"
 
+## [v0.1.3] — Unreleased
+
+### ⚡ Improvements
+
+*   Added `spec.Filter.Eval` to allow public evaluation of a single JSON node.
+    Used internally by `spec.FilterSelector.Select`.
+*   Added `spec.Segment.IsDescendant` to tell wether a segments selects just
+    from the current child node or also recursively selects from all of its
+    descendants.
+
+### 🪲 Bug Fixes
+
+*   Added missing "?" to the stringification of `spec.FilterSelector`.
+
+### 📔 Notes
+
+*   Made `spec.SliceSelector.Bounds` public.
+*   Made the underlying struct defining `spec.Wildcard` public, named it
+    `spec.WildcardSelector`.
+
+  [v0.1.3]: https://github.com/theory/jsonpath/compare/v0.1.2...v0.1.3
+
 ## [v0.1.2] — 2024-10-28
 
 ### 🪲 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file. It uses the
   [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
     "Semantic Versioning 2.0.0"
 
-## [v0.1.3] — Unreleased
+## [v0.2.0] — 2024-11-13
 
 ### ⚡ Improvements
 
@@ -27,7 +27,7 @@ All notable changes to this project will be documented in this file. It uses the
 *   Made the underlying struct defining `spec.Wildcard` public, named it
     `spec.WildcardSelector`.
 
-  [v0.1.3]: https://github.com/theory/jsonpath/compare/v0.1.2...v0.1.3
+  [v0.2.0]: https://github.com/theory/jsonpath/compare/v0.1.2...v0.2.0
 
 ## [v0.1.2] — 2024-10-28
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ brew-lint-depends:
 
 .PHONY: debian-lint-depends # Install linting tools on Debian
 debian-lint-depends:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin v1.59.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin v1.62.0
 
 .PHONY: install-generators # Install Go code generators
 install-generators:

--- a/spec/query_test.go
+++ b/spec/query_test.go
@@ -787,14 +787,14 @@ func TestQueryDescendants(t *testing.T) {
 
 	for _, tc := range []queryTestCase{
 		{
-			name:  "descendent_name",
+			name:  "descendant_name",
 			segs:  []*Segment{Descendant(Name("j"))},
 			input: json,
 			exp:   []any{1, 4},
 			rand:  true,
 		},
 		{
-			name:  "un_descendent_name",
+			name:  "un_descendant_name",
 			segs:  []*Segment{Descendant(Name("o"))},
 			input: json,
 			exp:   []any{map[string]any{"j": 1, "k": 2}},

--- a/spec/segment.go
+++ b/spec/segment.go
@@ -85,3 +85,7 @@ func (s *Segment) isSingular() bool {
 	}
 	return s.selectors[0].isSingular()
 }
+
+// IsDescendant returns true if the segment is a descendant selector that
+// recursively select the children of a JSON value.
+func (s *Segment) IsDescendant() bool { return s.descendant }

--- a/spec/segment_test.go
+++ b/spec/segment_test.go
@@ -83,6 +83,7 @@ func TestSegmentString(t *testing.T) {
 			t.Parallel()
 			a.Equal(tc.str, tc.seg.String())
 			a.Equal(tc.sing, tc.seg.isSingular())
+			a.Equal(tc.seg.descendant, tc.seg.IsDescendant())
 		})
 	}
 }
@@ -237,6 +238,7 @@ func TestSegmentQuery(t *testing.T) {
 			t.Parallel()
 			a.Equal(tc.seg.selectors, tc.seg.Selectors())
 			a.Equal(tc.sing, tc.seg.isSingular())
+			a.Equal(tc.seg.descendant, tc.seg.IsDescendant())
 			if tc.rand {
 				a.ElementsMatch(tc.exp, tc.seg.Select(tc.src, nil))
 			} else {
@@ -433,6 +435,7 @@ func TestDescendantSegmentQuery(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			a.False(tc.seg.isSingular())
+			a.True(tc.seg.IsDescendant())
 			if tc.rand {
 				a.ElementsMatch(tc.exp, tc.seg.Select(tc.src, nil))
 			} else {

--- a/spec/selector_test.go
+++ b/spec/selector_test.go
@@ -151,7 +151,7 @@ func TestSliceBounds(t *testing.T) {
 	json := []any{"a", "b", "c", "d", "e", "f", "g"}
 
 	extract := func(s SliceSelector) []any {
-		lower, upper := s.bounds(len(json))
+		lower, upper := s.Bounds(len(json))
 		res := make([]any, 0, len(json))
 		switch {
 		case s.step > 0:
@@ -273,7 +273,7 @@ func TestSliceBounds(t *testing.T) {
 			t.Parallel()
 			a.False(tc.slice.isSingular())
 			for _, lc := range tc.cases {
-				lower, upper := tc.slice.bounds(lc.length)
+				lower, upper := tc.slice.Bounds(lc.length)
 				a.Equal(lc.lower, lower)
 				a.Equal(lc.upper, upper)
 			}
@@ -543,7 +543,7 @@ func TestFilterSelector(t *testing.T) {
 			name:   "no_filter",
 			filter: Filter(LogicalOr{}),
 			exp:    []any{},
-			str:    "",
+			str:    "?",
 		},
 		{
 			name: "array_root",
@@ -553,7 +553,7 @@ func TestFilterSelector(t *testing.T) {
 			root:    []any{42, true, "hi"},
 			current: map[string]any{"x": 2},
 			exp:     []any{2},
-			str:     `$[0]`,
+			str:     `?$[0]`,
 		},
 		{
 			name: "array_root_false",
@@ -563,7 +563,7 @@ func TestFilterSelector(t *testing.T) {
 			root:    []any{42, true, "hi"},
 			current: map[string]any{"x": 2},
 			exp:     []any{},
-			str:     `$[4]`,
+			str:     `?$[4]`,
 		},
 		{
 			name: "object_root",
@@ -573,7 +573,7 @@ func TestFilterSelector(t *testing.T) {
 			root:    map[string]any{"x": 42, "y": "hi"},
 			current: map[string]any{"a": 2, "b": 3},
 			exp:     []any{2, 3},
-			str:     `$["y"]`,
+			str:     `?$["y"]`,
 			rand:    true,
 		},
 		{
@@ -584,7 +584,7 @@ func TestFilterSelector(t *testing.T) {
 			root:    map[string]any{"x": 42, "y": "hi"},
 			current: map[string]any{"a": 2, "b": 3},
 			exp:     []any{},
-			str:     `$["z"]`,
+			str:     `?$["z"]`,
 			rand:    true,
 		},
 		{
@@ -594,7 +594,7 @@ func TestFilterSelector(t *testing.T) {
 			}}}),
 			current: []any{[]any{42}},
 			exp:     []any{[]any{42}},
-			str:     `@[0]`,
+			str:     `?@[0]`,
 		},
 		{
 			name: "array_current_false",
@@ -603,7 +603,7 @@ func TestFilterSelector(t *testing.T) {
 			}}}),
 			current: []any{[]any{42}},
 			exp:     []any{},
-			str:     `@[1]`,
+			str:     `?@[1]`,
 		},
 		{
 			name: "object_current",
@@ -612,7 +612,7 @@ func TestFilterSelector(t *testing.T) {
 			}}}),
 			current: []any{map[string]any{"x": 42}},
 			exp:     []any{map[string]any{"x": 42}},
-			str:     `@["x"]`,
+			str:     `?@["x"]`,
 		},
 		{
 			name: "object_current_false",
@@ -621,7 +621,7 @@ func TestFilterSelector(t *testing.T) {
 			}}}),
 			current: []any{map[string]any{"x": 42}},
 			exp:     []any{},
-			str:     `@["y"]`,
+			str:     `?@["y"]`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
*   Add `spec.Filter.Eval` to allow public evaluation of a single JSON node. Used internally by `spec.FilterSelector.Select`.
*   Add `spec.Segment.IsDescendant` to tell wether a segments selects just from the current child node or also recursively selects from all of its descendants.
*   Make `spec.SliceSelector.Bounds` public.
*   Make the underlying struct defining `spec.Wildcard` public with the name `spec.WildcardSelector`.

Other changes:

*   Add missing "?" to the stringification of `spec.FilterSelector`.
*   Upgrade to `golangci-lint` v1.62 and disable `gosec` G602 false positives (securego/gosec#1250)