### PR TITLE
Add SelectLocated, golangci-lint, NormalizedPath

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -62,8 +62,7 @@ linters:
   # https://golangci-lint.run/usage/linters/#disabled-by-default
   disable:
     # Deprecated
-    - execinquery # Archived by the owner
-    - gomnd # Renamed to mnd
+    - exportloopref # Replaced by copyloopvar
 
     # Too strict.
     - depguard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to this project will be documented in this file. It uses the
   [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
     "Semantic Versioning 2.0.0"
 
+## [v0.3.0 ] — Unreleased
+
+### ⚡ Improvements
+
+*   Added `SelectLocated`. It works just like `Select`, but returns a slice of
+    `LocatedNode`s that pair the selected nodes with [RFC 9535-defined]
+    `NormalizedPath`s that uniquely identify their locations within the JSON
+    query argument.
+
+### 📚 Documentation
+
+*   Added `Select` and `SelectLocated` examples to the Go docs.
+
+  [v0.3.0]: https://github.com/theory/jsonpath/compare/v0.2.1...v0.3.0
+  [RFC 9535-defined]: https://www.rfc-editor.org/rfc/rfc9535#section-2.7
+
 ## [v0.2.1 ] — 2024-12-12
 
 ### 🪲 Bug Fixes

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ brew-lint-depends:
 
 .PHONY: debian-lint-depends # Install linting tools on Debian
 debian-lint-depends:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin v1.62.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin v1.62.2
 
 .PHONY: install-generators # Install Go code generators
 install-generators:

--- a/path.go
+++ b/path.go
@@ -49,6 +49,16 @@ func (p *Path) Select(input any) []any {
 	return p.q.Select(nil, input)
 }
 
+// SelectLocated returns the values that JSONPath query p selects from input
+// as [spec.LocatedNode] structs pair the values with the [normalized paths]
+// that identify them. Unless you have a specific need for the unique
+// normalized path for each value, you probably want to use [Path.Select].
+//
+// [normalized paths]: https://www.rfc-editor.org/rfc/rfc9535#section-2.7
+func (p *Path) SelectLocated(input any) []*spec.LocatedNode {
+	return p.q.SelectLocated(nil, input, spec.NormalizedPath{})
+}
+
 // Parser parses JSONPath strings into [*Path]s.
 type Parser struct {
 	reg *registry.Registry

--- a/path_example_test.go
+++ b/path_example_test.go
@@ -33,6 +33,51 @@ func Example() {
 	// Output: ["Nigel Rees","Evelyn Waugh","Herman Melville","J. R. R. Tolkien"]
 }
 
+func ExamplePath_Select() {
+	// Load some JSON.
+	menu := map[string]any{
+		"apps": map[string]any{
+			"guacamole": 19.99,
+			"salsa":     5.99,
+		},
+	}
+
+	// Parse a JSONPath and select from the input.
+	p := jsonpath.MustParse("$.apps.*")
+	result := p.Select(menu)
+
+	// Show the result.
+	for _, val := range result {
+		fmt.Printf("%v\n", val)
+	}
+	// Unordered output:
+	// 19.99
+	// 5.99
+}
+
+func ExamplePath_SelectLocated() {
+	// Load some JSON.
+	menu := map[string]any{
+		"apps": map[string]any{
+			"guacamole": 19.99,
+			"salsa":     5.99,
+		},
+	}
+
+	// Parse a JSONPath and select from the input.
+	p := jsonpath.MustParse("$.apps.*")
+	result := p.SelectLocated(menu)
+
+	// Show the result.
+	for _, node := range result {
+		fmt.Printf("%v: %v\n", node.Path, node.Node)
+	}
+
+	// Unordered output:
+	// $['apps']['guacamole']: 19.99
+	// $['apps']['salsa']: 5.99
+}
+
 // Use the Parser to parse a collection of paths.
 func ExampleParser() {
 	// Create a new parser using the default function registry.

--- a/path_test.go
+++ b/path_test.go
@@ -10,18 +10,25 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/theory/jsonpath/registry"
+	"github.com/theory/jsonpath/spec"
 )
+
+func book(idx int) spec.NormalizedPath {
+	return spec.NormalizedPath{spec.Name("store"), spec.Name("book"), spec.Index(idx)}
+}
 
 func TestParseSpecExamples(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
 	val := specExampleJSON(t)
 	store, _ := val["store"].(map[string]any)
+	books, _ := store["book"].([]any)
 
 	for _, tc := range []struct {
 		name string
 		path string
 		exp  []any
+		loc  []*spec.LocatedNode
 		size int
 		rand bool
 	}{
@@ -29,101 +36,84 @@ func TestParseSpecExamples(t *testing.T) {
 			name: "example_1",
 			path: `$.store.book[*].author`,
 			exp:  []any{"Nigel Rees", "Evelyn Waugh", "Herman Melville", "J. R. R. Tolkien"},
+			loc: []*spec.LocatedNode{
+				{Path: append(book(0), spec.Name("author")), Node: "Nigel Rees"},
+				{Path: append(book(1), spec.Name("author")), Node: "Evelyn Waugh"},
+				{Path: append(book(2), spec.Name("author")), Node: "Herman Melville"},
+				{Path: append(book(3), spec.Name("author")), Node: "J. R. R. Tolkien"},
+			},
 		},
 		{
 			name: "example_2",
 			path: `$..author`,
 			exp:  []any{"Nigel Rees", "Evelyn Waugh", "Herman Melville", "J. R. R. Tolkien"},
+			loc: []*spec.LocatedNode{
+				{Path: append(book(0), spec.Name("author")), Node: "Nigel Rees"},
+				{Path: append(book(1), spec.Name("author")), Node: "Evelyn Waugh"},
+				{Path: append(book(2), spec.Name("author")), Node: "Herman Melville"},
+				{Path: append(book(3), spec.Name("author")), Node: "J. R. R. Tolkien"},
+			},
 		},
 		{
 			name: "example_3",
 			path: `$.store.*`,
 			exp:  []any{store["book"], store["bicycle"]},
+			loc: []*spec.LocatedNode{
+				{Path: spec.NormalizedPath{spec.Name("store"), spec.Name("book")}, Node: store["book"]},
+				{Path: spec.NormalizedPath{spec.Name("store"), spec.Name("bicycle")}, Node: store["bicycle"]},
+			},
 			rand: true,
 		},
 		{
 			name: "example_4",
 			path: `$.store..price`,
 			exp:  []any{399., 8.95, 12.99, 8.99, 22.99},
+			loc: []*spec.LocatedNode{
+				{Path: spec.NormalizedPath{spec.Name("store"), spec.Name("bicycle"), spec.Name("price")}, Node: 399.},
+				{Path: append(book(0), spec.Name("price")), Node: 8.95},
+				{Path: append(book(1), spec.Name("price")), Node: 12.99},
+				{Path: append(book(2), spec.Name("price")), Node: 8.99},
+				{Path: append(book(3), spec.Name("price")), Node: 22.99},
+			},
 			rand: true,
 		},
 		{
 			name: "example_5",
 			path: `$..book[2]`,
-			exp: []any{map[string]any{
-				"category": "fiction",
-				"author":   "Herman Melville",
-				"title":    "Moby Dick",
-				"isbn":     "0-553-21311-3",
-				"price":    8.99,
-			}},
+			exp:  []any{books[2]},
+			loc:  []*spec.LocatedNode{{Path: book(2), Node: books[2]}},
 		},
 		{
 			name: "example_6",
 			path: `$..book[-1]`,
-			exp: []any{map[string]any{
-				"category": "fiction",
-				"author":   "J. R. R. Tolkien",
-				"title":    "The Lord of the Rings",
-				"isbn":     "0-395-19395-8",
-				"price":    22.99,
-			}},
+			exp:  []any{books[3]},
+			loc:  []*spec.LocatedNode{{Path: book(3), Node: books[3]}},
 		},
 		{
 			name: "example_7",
 			path: `$..book[0,1]`,
-			exp: []any{
-				map[string]any{
-					"category": "reference",
-					"author":   "Nigel Rees",
-					"title":    "Sayings of the Century",
-					"price":    8.95,
-				},
-				map[string]any{
-					"category": "fiction",
-					"author":   "Evelyn Waugh",
-					"title":    "Sword of Honour",
-					"price":    12.99,
-				},
+			exp:  []any{books[0], books[1]},
+			loc: []*spec.LocatedNode{
+				{Path: book(0), Node: books[0]},
+				{Path: book(1), Node: books[1]},
 			},
 		},
 		{
 			name: "example_8",
 			path: `$..book[?(@.isbn)]`,
-			exp: []any{
-				map[string]any{
-					"category": "fiction",
-					"author":   "Herman Melville",
-					"title":    "Moby Dick",
-					"isbn":     "0-553-21311-3",
-					"price":    8.99,
-				},
-				map[string]any{
-					"category": "fiction",
-					"author":   "J. R. R. Tolkien",
-					"title":    "The Lord of the Rings",
-					"isbn":     "0-395-19395-8",
-					"price":    22.99,
-				},
+			exp:  []any{books[2], books[3]},
+			loc: []*spec.LocatedNode{
+				{Path: book(2), Node: books[2]},
+				{Path: book(3), Node: books[3]},
 			},
 		},
 		{
 			name: "example_9",
 			path: `$..book[?(@.price<10)]`,
-			exp: []any{
-				map[string]any{
-					"category": "reference",
-					"author":   "Nigel Rees",
-					"title":    "Sayings of the Century",
-					"price":    8.95,
-				},
-				map[string]any{
-					"category": "fiction",
-					"author":   "Herman Melville",
-					"title":    "Moby Dick",
-					"isbn":     "0-553-21311-3",
-					"price":    8.99,
-				},
+			exp:  []any{books[0], books[2]},
+			loc: []*spec.LocatedNode{
+				{Path: book(0), Node: books[0]},
+				{Path: book(2), Node: books[2]},
 			},
 		},
 		{
@@ -139,15 +129,19 @@ func TestParseSpecExamples(t *testing.T) {
 			a.Equal(p.q, p.Query())
 			a.Equal(p.q.String(), p.String())
 			res := p.Select(val)
+			loc := p.SelectLocated(val)
 
 			if tc.exp != nil {
 				if tc.rand {
 					a.ElementsMatch(tc.exp, res)
+					a.ElementsMatch(tc.loc, loc)
 				} else {
 					a.Equal(tc.exp, res)
+					a.Equal(tc.loc, loc)
 				}
 			} else {
 				a.Len(res, tc.size)
+				a.Len(loc, tc.size)
 			}
 		})
 	}

--- a/spec/normalized.go
+++ b/spec/normalized.go
@@ -1,0 +1,54 @@
+package spec
+
+import (
+	"strings"
+)
+
+// NormalSelector represents a single selector in a normalized path.
+// Implemented by [Name] and [Index].
+type NormalSelector interface {
+	// writeNormalizedTo writes n to buf formatted as a [normalized path] element.
+	//
+	// [normalized path]: https://www.rfc-editor.org/rfc/rfc9535#section-2.7
+	writeNormalizedTo(buf *strings.Builder)
+}
+
+// NormalizedPath represents a normalized path identifying a single value in a
+// JSON query argument, as [defined by RFC 9535].
+//
+// [defined by RFC 9535]: https://www.rfc-editor.org/rfc/rfc9535#name-normalized-paths
+type NormalizedPath []NormalSelector
+
+// String returns the string representation of np.
+func (np NormalizedPath) String() string {
+	buf := new(strings.Builder)
+	buf.WriteRune('$')
+	for _, e := range np {
+		e.writeNormalizedTo(buf)
+	}
+	return buf.String()
+}
+
+// MarshalText marshals np into text. It implements [encoding.TextMarshaler].
+func (np NormalizedPath) MarshalText() ([]byte, error) {
+	return []byte(np.String()), nil
+}
+
+// LocatedNode pairs a value with its location within the JSON query argument
+// from which it was selected.
+type LocatedNode struct {
+	// Node is the value selected from a JSON query argument.
+	Node any `json:"node"`
+
+	// Path is the normalized path that uniquely identifies the location of
+	// Node in a JSON query argument.
+	Path NormalizedPath `json:"path"`
+}
+
+// newLocatedNode creates and returns a new [Node]. It makes a copy of path.
+func newLocatedNode(path NormalizedPath, node any) *LocatedNode {
+	return &LocatedNode{
+		Path: NormalizedPath(append(make([]NormalSelector, 0, len(path)), path...)),
+		Node: node,
+	}
+}

--- a/spec/normalized_test.go
+++ b/spec/normalized_test.go
@@ -1,0 +1,146 @@
+package spec
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalSelector(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	for _, tc := range []struct {
+		name string
+		elem NormalSelector
+		exp  string
+	}{
+		{
+			name: "object_value",
+			elem: Name("a"),
+			exp:  `['a']`,
+		},
+		{
+			name: "array_index",
+			elem: Index(1),
+			exp:  `[1]`,
+		},
+		{
+			name: "escape_apostrophes",
+			elem: Name("'hi'"),
+			exp:  `['\'hi\'']`,
+		},
+		{
+			name: "escapes",
+			elem: Name("'\b\f\n\r\t\\'"),
+			exp:  `['\'\b\f\n\r\t\\\'']`,
+		},
+		{
+			name: "escape_vertical_unicode",
+			elem: Name("\u000B"),
+			exp:  `['\u000b']`,
+		},
+		{
+			name: "escape_unicode_null",
+			elem: Name("\u0000"),
+			exp:  `['\u0000']`,
+		},
+		{
+			name: "escape_unicode_runes",
+			elem: Name("\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u000e\u000F"),
+			exp:  `['\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u000e\u000f']`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			buf := new(strings.Builder)
+			tc.elem.writeNormalizedTo(buf)
+			a.Equal(tc.exp, buf.String())
+		})
+	}
+}
+
+func TestNormalizedPath(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+
+	for _, tc := range []struct {
+		name string
+		path NormalizedPath
+		exp  string
+	}{
+		{
+			name: "object_value",
+			path: NormalizedPath{Name("a")},
+			exp:  "$['a']",
+		},
+		{
+			name: "array_index",
+			path: NormalizedPath{Index(1)},
+			exp:  "$[1]",
+		},
+		{
+			name: "neg_for_len_5",
+			path: NormalizedPath{Index(2)},
+			exp:  "$[2]",
+		},
+		{
+			name: "nested_structure",
+			path: NormalizedPath{Name("a"), Name("b"), Index(1)},
+			exp:  "$['a']['b'][1]",
+		},
+		{
+			name: "unicode_escape",
+			path: NormalizedPath{Name("\u000B")},
+			exp:  `$['\u000b']`,
+		},
+		{
+			name: "unicode_character",
+			path: NormalizedPath{Name("\u0061")},
+			exp:  "$['a']",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a.Equal(tc.exp, tc.path.String())
+		})
+	}
+}
+
+func TestLocatedNode(t *testing.T) {
+	t.Parallel()
+	a := assert.New(t)
+	r := require.New(t)
+
+	for _, tc := range []struct {
+		name string
+		node LocatedNode
+		exp  string
+	}{
+		{
+			name: "simple",
+			node: LocatedNode{Path: NormalizedPath{Name("a")}, Node: "foo"},
+			exp:  `{"path": "$['a']", "node": "foo"}`,
+		},
+		{
+			name: "double_quoted_path",
+			node: LocatedNode{Path: NormalizedPath{Name(`"a"`)}, Node: 42},
+			exp:  `{"path": "$['\"a\"']", "node": 42}`,
+		},
+		{
+			name: "single_quoted_path",
+			node: LocatedNode{Path: NormalizedPath{Name(`'a'`)}, Node: true},
+			exp:  `{"path": "$['\\'a\\'']", "node": true}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			json, err := json.Marshal(tc.node)
+			r.NoError(err)
+			a.JSONEq(tc.exp, string(json))
+		})
+	}
+}

--- a/spec/query.go
+++ b/spec/query.go
@@ -33,7 +33,7 @@ func (q *PathQuery) String() string {
 }
 
 // Select selects q.segments from current or root and returns the result.
-// Returns just input if q has no segments. Defined by the [Selector]
+// Returns just current if q has no segments. Defined by the [Selector]
 // interface.
 func (q *PathQuery) Select(current, root any) []any {
 	res := []any{current}
@@ -44,6 +44,27 @@ func (q *PathQuery) Select(current, root any) []any {
 		segRes := []any{}
 		for _, v := range res {
 			segRes = append(segRes, seg.Select(v, root)...)
+		}
+		res = segRes
+	}
+
+	return res
+}
+
+// SelectLocated selects q.segments from current or root and returns the
+// resulting values as [LocatedNode] structs. Returns just current if q has no
+// segments. Defined by the [Selector] interface.
+func (q *PathQuery) SelectLocated(current, root any, parent NormalizedPath) []*LocatedNode {
+	res := []*LocatedNode{nil}
+	if q.root {
+		res[0] = newLocatedNode(nil, root)
+	} else {
+		res[0] = newLocatedNode(parent, current)
+	}
+	for _, seg := range q.segments {
+		segRes := []*LocatedNode{}
+		for _, v := range res {
+			segRes = append(segRes, seg.SelectLocated(v.Node, root, v.Path)...)
 		}
 		res = segRes
 	}

--- a/spec/query_test.go
+++ b/spec/query_test.go
@@ -96,6 +96,7 @@ type queryTestCase struct {
 	segs  []*Segment
 	input any
 	exp   []any
+	loc   []*LocatedNode
 	rand  bool
 }
 
@@ -108,8 +109,10 @@ func (tc queryTestCase) run(a *assert.Assertions) {
 	// Test both.
 	if tc.rand {
 		a.ElementsMatch(tc.exp, q.Select(tc.input, nil))
+		a.ElementsMatch(tc.loc, q.SelectLocated(tc.input, nil, NormalizedPath{}))
 	} else {
 		a.Equal(tc.exp, q.Select(tc.input, nil))
+		a.Equal(tc.loc, q.SelectLocated(tc.input, nil, NormalizedPath{}))
 	}
 }
 
@@ -122,31 +125,47 @@ func TestQueryObject(t *testing.T) {
 			name:  "root",
 			input: map[string]any{"x": true, "y": []any{1, 2}},
 			exp:   []any{map[string]any{"x": true, "y": []any{1, 2}}},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{}, Node: map[string]any{"x": true, "y": []any{1, 2}}},
+			},
 		},
 		{
 			name:  "one_key_scalar",
 			segs:  []*Segment{Child(Name("x"))},
 			input: map[string]any{"x": true, "y": []any{1, 2}},
 			exp:   []any{true},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("x")}, Node: true},
+			},
 		},
 		{
 			name:  "one_key_array",
 			segs:  []*Segment{Child(Name("y"))},
 			input: map[string]any{"x": true, "y": []any{1, 2}},
 			exp:   []any{[]any{1, 2}},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("y")}, Node: []any{1, 2}},
+			},
 		},
 		{
 			name:  "one_key_object",
 			segs:  []*Segment{Child(Name("y"))},
 			input: map[string]any{"x": true, "y": map[string]any{"a": 1}},
 			exp:   []any{map[string]any{"a": 1}},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("y")}, Node: map[string]any{"a": 1}},
+			},
 		},
 		{
 			name:  "multiple_keys",
 			segs:  []*Segment{Child(Name("x"), Name("y"))},
 			input: map[string]any{"x": true, "y": []any{1, 2}, "z": "hi"},
 			exp:   []any{true, []any{1, 2}},
-			rand:  true,
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("x")}, Node: true},
+				{Path: NormalizedPath{Name("y")}, Node: []any{1, 2}},
+			},
+			rand: true,
 		},
 		{
 			name: "three_level_path",
@@ -166,6 +185,9 @@ func TestQueryObject(t *testing.T) {
 				"y": 1,
 			},
 			exp: []any{[]any{1, 2}},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("x"), Name("a"), Name("i")}, Node: []any{1, 2}},
+			},
 		},
 		{
 			name: "wildcard_keys",
@@ -177,7 +199,13 @@ func TestQueryObject(t *testing.T) {
 				"x": map[string]any{"a": "go", "b": 2, "c": 5},
 				"y": map[string]any{"a": 2, "b": 3, "d": 3},
 			},
-			exp:  []any{"go", 2, 2, 3},
+			exp: []any{"go", 2, 2, 3},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("x"), Name("a")}, Node: "go"},
+				{Path: NormalizedPath{Name("x"), Name("b")}, Node: 2},
+				{Path: NormalizedPath{Name("y"), Name("a")}, Node: 2},
+				{Path: NormalizedPath{Name("y"), Name("b")}, Node: 3},
+			},
 			rand: true,
 		},
 		{
@@ -190,7 +218,13 @@ func TestQueryObject(t *testing.T) {
 				"x": []any{"a", "go", "b", 2, "c", 5},
 				"y": []any{"a", 2, "b", 3, "d", 3},
 			},
-			exp:  []any{"a", "go", "a", 2},
+			exp: []any{"a", "go", "a", 2},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("x"), Index(0)}, Node: "a"},
+				{Path: NormalizedPath{Name("x"), Index(1)}, Node: "go"},
+				{Path: NormalizedPath{Name("y"), Index(0)}, Node: "a"},
+				{Path: NormalizedPath{Name("y"), Index(1)}, Node: 2},
+			},
 			rand: true,
 		},
 		{
@@ -201,30 +235,37 @@ func TestQueryObject(t *testing.T) {
 				"y": []any{"a"},
 			},
 			exp: []any{"go"},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("x"), Index(1)}, Node: "go"},
+			},
 		},
 		{
 			name:  "nonexistent_key",
 			segs:  []*Segment{Child(Name("x"))},
 			input: map[string]any{"y": []any{1, 2}},
 			exp:   []any{},
+			loc:   []*LocatedNode{},
 		},
 		{
 			name:  "nonexistent_branch_key",
 			segs:  []*Segment{Child(Name("x")), Child(Name("z"))},
 			input: map[string]any{"y": []any{1, 2}},
 			exp:   []any{},
+			loc:   []*LocatedNode{},
 		},
 		{
 			name:  "wildcard_then_nonexistent_key",
 			segs:  []*Segment{Child(Wildcard), Child(Name("x"))},
 			input: map[string]any{"y": map[string]any{"a": 1}},
 			exp:   []any{},
+			loc:   []*LocatedNode{},
 		},
 		{
 			name:  "not_an_object",
 			segs:  []*Segment{Child(Name("x")), Child(Name("y"))},
 			input: map[string]any{"x": true},
 			exp:   []any{},
+			loc:   []*LocatedNode{},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -243,48 +284,68 @@ func TestQueryArray(t *testing.T) {
 			name:  "root",
 			input: []any{"x", true, "y", []any{1, 2}},
 			exp:   []any{[]any{"x", true, "y", []any{1, 2}}},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{}, Node: []any{"x", true, "y", []any{1, 2}}},
+			},
 		},
 		{
 			name:  "index_zero",
 			segs:  []*Segment{Child(Index(0))},
 			input: []any{"x", true, "y", []any{1, 2}},
 			exp:   []any{"x"},
+			loc:   []*LocatedNode{{Path: NormalizedPath{Index(0)}, Node: "x"}},
 		},
 		{
 			name:  "index_one",
 			segs:  []*Segment{Child(Index(1))},
 			input: []any{"x", true, "y", []any{1, 2}},
 			exp:   []any{true},
+			loc:   []*LocatedNode{{Path: NormalizedPath{Index(1)}, Node: true}},
 		},
 		{
 			name:  "index_three",
 			segs:  []*Segment{Child(Index(3))},
 			input: []any{"x", true, "y", []any{1, 2}},
 			exp:   []any{[]any{1, 2}},
+			loc:   []*LocatedNode{{Path: NormalizedPath{Index(3)}, Node: []any{1, 2}}},
 		},
 		{
 			name:  "multiple_indexes",
 			segs:  []*Segment{Child(Index(1), Index(3))},
 			input: []any{"x", true, "y", []any{1, 2}},
 			exp:   []any{true, []any{1, 2}},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(1)}, Node: true},
+				{Path: NormalizedPath{Index(3)}, Node: []any{1, 2}},
+			},
 		},
 		{
 			name:  "nested_indices",
 			segs:  []*Segment{Child(Index(0)), Child(Index(0))},
 			input: []any{[]any{1, 2}, "x", true, "y"},
 			exp:   []any{1},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(0)}, Node: 1},
+			},
 		},
 		{
 			name:  "nested_multiple_indices",
 			segs:  []*Segment{Child(Index(0)), Child(Index(0), Index(1))},
 			input: []any{[]any{1, 2, 3}, "x", true, "y"},
 			exp:   []any{1, 2},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(0)}, Node: 1},
+				{Path: NormalizedPath{Index(0), Index(1)}, Node: 2},
+			},
 		},
 		{
 			name:  "nested_index_gaps",
 			segs:  []*Segment{Child(Index(1)), Child(Index(1))},
 			input: []any{"x", []any{1, 2}, true, "y"},
 			exp:   []any{2},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(1), Index(1)}, Node: 2},
+			},
 		},
 		{
 			name: "three_level_index_path",
@@ -295,6 +356,9 @@ func TestQueryArray(t *testing.T) {
 			},
 			input: []any{[]any{[]any{42, 12}, 2}, "x", true, "y"},
 			exp:   []any{42},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(0), Index(0)}, Node: 42},
+			},
 		},
 		{
 			name: "mixed_nesting",
@@ -308,7 +372,12 @@ func TestQueryArray(t *testing.T) {
 				true,
 				map[string]any{"y": "hi", "z": 1, "x": "no"},
 			},
-			exp:  []any{2, "hi", 1},
+			exp: []any{2, "hi", 1},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(1)}, Node: 2},
+				{Path: NormalizedPath{Index(3), Name("y")}, Node: "hi"},
+				{Path: NormalizedPath{Index(3), Name("z")}, Node: 1},
+			},
 			rand: true,
 		},
 		{
@@ -316,36 +385,51 @@ func TestQueryArray(t *testing.T) {
 			segs:  []*Segment{Child(Wildcard), Child(Index(0), Index(2))},
 			input: []any{[]any{1, 2, 3}, []any{3, 2, 1}, []any{4, 5, 6}},
 			exp:   []any{1, 3, 3, 1, 4, 6},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(0)}, Node: 1},
+				{Path: NormalizedPath{Index(0), Index(2)}, Node: 3},
+				{Path: NormalizedPath{Index(1), Index(0)}, Node: 3},
+				{Path: NormalizedPath{Index(1), Index(2)}, Node: 1},
+				{Path: NormalizedPath{Index(2), Index(0)}, Node: 4},
+				{Path: NormalizedPath{Index(2), Index(2)}, Node: 6},
+			},
 		},
 		{
 			name:  "nonexistent_index",
 			segs:  []*Segment{Child(Index(3))},
 			input: []any{"y", []any{1, 2}},
 			exp:   []any{},
+			loc:   []*LocatedNode{},
 		},
 		{
 			name:  "nonexistent_child_index",
 			segs:  []*Segment{Child(Wildcard), Child(Index(3))},
 			input: []any{[]any{0, 1, 2, 3}, []any{0, 1, 2}},
 			exp:   []any{3},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(3)}, Node: 3},
+			},
 		},
 		{
 			name:  "not_an_array_index_1",
 			segs:  []*Segment{Child(Index(1)), Child(Index(0))},
 			input: []any{"x", true},
 			exp:   []any{},
+			loc:   []*LocatedNode{},
 		},
 		{
 			name:  "not_an_array_index_0",
 			segs:  []*Segment{Child(Index(0)), Child(Index(0))},
 			input: []any{"x", true},
 			exp:   []any{},
+			loc:   []*LocatedNode{},
 		},
 		{
 			name:  "wildcard_not_an_array_index_1",
 			segs:  []*Segment{Child(Wildcard), Child(Index(0))},
 			input: []any{"x", true},
 			exp:   []any{},
+			loc:   []*LocatedNode{},
 		},
 		{
 			name: "mix_wildcard_keys",
@@ -359,7 +443,18 @@ func TestQueryArray(t *testing.T) {
 				map[string]any{"x": true, "y": 21},
 				[]any{34, 53, 23},
 			},
-			exp:  []any{"hi", "go", "bo", 42, true, 21, 53, "bo", 42},
+			exp: []any{"hi", "go", "bo", 42, true, 21, 53, "bo", 42},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Name("x")}, Node: "hi"},
+				{Path: NormalizedPath{Index(0), Name("y")}, Node: "go"},
+				{Path: NormalizedPath{Index(1), Name("x")}, Node: "bo"},
+				{Path: NormalizedPath{Index(1), Name("y")}, Node: 42},
+				{Path: NormalizedPath{Index(2), Name("x")}, Node: true},
+				{Path: NormalizedPath{Index(2), Name("y")}, Node: 21},
+				{Path: NormalizedPath{Index(3), Index(1)}, Node: 53},
+				{Path: NormalizedPath{Index(1), Name("x")}, Node: "bo"},
+				{Path: NormalizedPath{Index(1), Name("y")}, Node: 42},
+			},
 			rand: true,
 		},
 		{
@@ -374,6 +469,12 @@ func TestQueryArray(t *testing.T) {
 				map[string]any{"x": true},
 			},
 			exp: []any{"hi", "bo", true, "bo"},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Name("x")}, Node: "hi"},
+				{Path: NormalizedPath{Index(1), Name("x")}, Node: "bo"},
+				{Path: NormalizedPath{Index(2), Name("x")}, Node: true},
+				{Path: NormalizedPath{Index(1), Name("x")}, Node: "bo"},
+			},
 		},
 		{
 			name: "mix_wildcard_index",
@@ -387,6 +488,16 @@ func TestQueryArray(t *testing.T) {
 				[]any{"x", true, 21},
 			},
 			exp: []any{"x", "hi", "x", "bo", "x", true, "x", "bo"},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(0), Index(1)}, Node: "hi"},
+				{Path: NormalizedPath{Index(1), Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(1), Index(1)}, Node: "bo"},
+				{Path: NormalizedPath{Index(2), Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(2), Index(1)}, Node: true},
+				{Path: NormalizedPath{Index(1), Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(1), Index(1)}, Node: "bo"},
+			},
 		},
 		{
 			name: "mix_wildcard_nonexistent_index",
@@ -400,6 +511,12 @@ func TestQueryArray(t *testing.T) {
 				[]any{"x", true, 21},
 			},
 			exp: []any{"x", "x", "x", "x"},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(1), Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(2), Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(1), Index(0)}, Node: "x"},
+			},
 		},
 		{
 			name: "wildcard_nonexistent_key",
@@ -409,6 +526,9 @@ func TestQueryArray(t *testing.T) {
 				map[string]any{"z": 3, "b": 4},
 			},
 			exp: []any{1},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Name("a")}, Node: 1},
+			},
 		},
 		{
 			name: "wildcard_nonexistent_middle_key",
@@ -420,6 +540,10 @@ func TestQueryArray(t *testing.T) {
 				map[string]any{"z": 3, "b": 4},
 			},
 			exp: []any{1, 5},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Name("a")}, Node: 1},
+				{Path: NormalizedPath{Index(2), Name("a")}, Node: 5},
+			},
 		},
 		{
 			name: "wildcard_nested_nonexistent_key",
@@ -438,6 +562,9 @@ func TestQueryArray(t *testing.T) {
 				},
 			},
 			exp: []any{1},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Name("x"), Name("a")}, Node: 1},
+			},
 		},
 		{
 			name: "wildcard_nested_nonexistent_index",
@@ -456,6 +583,9 @@ func TestQueryArray(t *testing.T) {
 				},
 			},
 			exp: []any{2},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Name("x"), Index(1)}, Node: 2},
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -475,66 +605,121 @@ func TestQuerySlice(t *testing.T) {
 			segs:  []*Segment{Child(Slice(0, 2))},
 			input: []any{"x", true, "y", []any{1, 2}},
 			exp:   []any{"x", true},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(1)}, Node: true},
+			},
 		},
 		{
 			name:  "slice_0_1",
 			segs:  []*Segment{Child(Slice(0, 1))},
 			input: []any{"x", true, "y", []any{1, 2}},
 			exp:   []any{"x"},
+			loc:   []*LocatedNode{{Path: NormalizedPath{Index(0)}, Node: "x"}},
 		},
 		{
 			name:  "slice_2_5",
 			segs:  []*Segment{Child(Slice(2, 5))},
 			input: []any{"x", true, "y", []any{1, 2}, 42, nil, 78},
 			exp:   []any{"y", []any{1, 2}, 42},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(2)}, Node: "y"},
+				{Path: NormalizedPath{Index(3)}, Node: []any{1, 2}},
+				{Path: NormalizedPath{Index(4)}, Node: 42},
+			},
 		},
 		{
 			name:  "slice_2_5_over_len",
 			segs:  []*Segment{Child(Slice(2, 5))},
 			input: []any{"x", true, "y"},
 			exp:   []any{"y"},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(2)}, Node: "y"},
+			},
 		},
 		{
 			name:  "slice_defaults",
 			segs:  []*Segment{Child(Slice())},
 			input: []any{"x", true, "y", []any{1, 2}, 42, nil, 78},
 			exp:   []any{"x", true, "y", []any{1, 2}, 42, nil, 78},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(1)}, Node: true},
+				{Path: NormalizedPath{Index(2)}, Node: "y"},
+				{Path: NormalizedPath{Index(3)}, Node: []any{1, 2}},
+				{Path: NormalizedPath{Index(4)}, Node: 42},
+				{Path: NormalizedPath{Index(5)}, Node: nil},
+				{Path: NormalizedPath{Index(6)}, Node: 78},
+			},
 		},
 		{
 			name:  "default_start",
 			segs:  []*Segment{Child(Slice(nil, 2))},
 			input: []any{"x", true, "y", []any{1, 2}, 42, nil, 78},
 			exp:   []any{"x", true},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(1)}, Node: true},
+			},
 		},
 		{
 			name:  "default_end",
 			segs:  []*Segment{Child(Slice(2))},
 			input: []any{"x", true, "y", []any{1, 2}, 42, nil, 78},
 			exp:   []any{"y", []any{1, 2}, 42, nil, 78},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(2)}, Node: "y"},
+				{Path: NormalizedPath{Index(3)}, Node: []any{1, 2}},
+				{Path: NormalizedPath{Index(4)}, Node: 42},
+				{Path: NormalizedPath{Index(5)}, Node: nil},
+				{Path: NormalizedPath{Index(6)}, Node: 78},
+			},
 		},
 		{
 			name:  "step_2",
 			segs:  []*Segment{Child(Slice(nil, nil, 2))},
 			input: []any{"x", true, "y", []any{1, 2}, 42, nil, 78},
 			exp:   []any{"x", "y", 42, 78},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(2)}, Node: "y"},
+				{Path: NormalizedPath{Index(4)}, Node: 42},
+				{Path: NormalizedPath{Index(6)}, Node: 78},
+			},
 		},
 		{
 			name:  "step_3",
 			segs:  []*Segment{Child(Slice(nil, nil, 3))},
 			input: []any{"x", true, "y", []any{1, 2}, 42, nil, 78},
 			exp:   []any{"x", []any{1, 2}, 78},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(3)}, Node: []any{1, 2}},
+				{Path: NormalizedPath{Index(6)}, Node: 78},
+			},
 		},
 		{
 			name:  "multiple_slices",
 			segs:  []*Segment{Child(Slice(0, 1), Slice(3, 4))},
 			input: []any{"x", true, "y", []any{1, 2}, 42, nil, 78},
 			exp:   []any{"x", []any{1, 2}},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(3)}, Node: []any{1, 2}},
+			},
 		},
 		{
 			name:  "overlapping_slices",
 			segs:  []*Segment{Child(Slice(0, 3), Slice(2, 4))},
 			input: []any{"x", true, "y", []any{1, 2}, 42, nil, 78},
 			exp:   []any{"x", true, "y", "y", []any{1, 2}},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(1)}, Node: true},
+				{Path: NormalizedPath{Index(2)}, Node: "y"},
+				{Path: NormalizedPath{Index(2)}, Node: "y"},
+				{Path: NormalizedPath{Index(3)}, Node: []any{1, 2}},
+			},
 		},
 		{
 			name: "nested_slices",
@@ -546,6 +731,10 @@ func TestQuerySlice(t *testing.T) {
 				"x", true, "y",
 			},
 			exp: []any{42, "on"},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(1)}, Node: 42},
+				{Path: NormalizedPath{Index(1), Index(1)}, Node: "on"},
+			},
 		},
 		{
 			name: "nested_multiple_indices",
@@ -560,6 +749,14 @@ func TestQuerySlice(t *testing.T) {
 				"x", true, "y",
 			},
 			exp: []any{42, 64, []any{}, "on", 88, []any{1}},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(1)}, Node: 42},
+				{Path: NormalizedPath{Index(0), Index(3)}, Node: 64},
+				{Path: NormalizedPath{Index(0), Index(4)}, Node: []any{}},
+				{Path: NormalizedPath{Index(1), Index(1)}, Node: "on"},
+				{Path: NormalizedPath{Index(1), Index(3)}, Node: 88},
+				{Path: NormalizedPath{Index(1), Index(4)}, Node: []any{1}},
+			},
 		},
 		{
 			name: "three_level_slice_path",
@@ -574,6 +771,10 @@ func TestQuerySlice(t *testing.T) {
 				"x", true, "y",
 			},
 			exp: []any{42, 16},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(0), Index(0)}, Node: 42},
+				{Path: NormalizedPath{Index(1), Index(0), Index(0)}, Node: 16},
+			},
 		},
 		{
 			name: "varying_nesting_levels_mixed",
@@ -590,6 +791,11 @@ func TestQuerySlice(t *testing.T) {
 				"go",
 			},
 			exp: []any{42, "hi", 1},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(0), Index(0)}, Node: 42},
+				{Path: NormalizedPath{Index(2), Index(0), Name("y")}, Node: "hi"},
+				{Path: NormalizedPath{Index(2), Index(0), Name("z")}, Node: 1},
+			},
 		},
 		{
 			name: "wildcard_slices_index",
@@ -603,36 +809,55 @@ func TestQuerySlice(t *testing.T) {
 				[]any{4, 5, 6, 7, 8},
 			},
 			exp: []any{1, 2, 4, 3, 2, 0, 4, 5, 7},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(0)}, Node: 1},
+				{Path: NormalizedPath{Index(0), Index(1)}, Node: 2},
+				{Path: NormalizedPath{Index(0), Index(3)}, Node: 4},
+				{Path: NormalizedPath{Index(1), Index(0)}, Node: 3},
+				{Path: NormalizedPath{Index(1), Index(1)}, Node: 2},
+				{Path: NormalizedPath{Index(1), Index(3)}, Node: 0},
+				{Path: NormalizedPath{Index(2), Index(0)}, Node: 4},
+				{Path: NormalizedPath{Index(2), Index(1)}, Node: 5},
+				{Path: NormalizedPath{Index(2), Index(3)}, Node: 7},
+			},
 		},
 		{
 			name:  "nonexistent_slice",
 			segs:  []*Segment{Child(Slice(3, 5))},
 			input: []any{"y", []any{1, 2}},
 			exp:   []any{},
+			loc:   []*LocatedNode{},
 		},
 		{
 			name:  "nonexistent_branch_index",
 			segs:  []*Segment{Child(Wildcard), Child(Slice(3, 5))},
 			input: []any{[]any{0, 1, 2, 3, 4}, []any{0, 1, 2}},
 			exp:   []any{3, 4},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(3)}, Node: 3},
+				{Path: NormalizedPath{Index(0), Index(4)}, Node: 4},
+			},
 		},
 		{
 			name:  "not_an_array_index_1",
 			segs:  []*Segment{Child(Index(1)), Child(Index(0))},
 			input: []any{"x", true},
 			exp:   []any{},
+			loc:   []*LocatedNode{},
 		},
 		{
 			name:  "not_an_array",
 			segs:  []*Segment{Child(Slice(0, 5)), Child(Index(0))},
 			input: []any{"x", true},
 			exp:   []any{},
+			loc:   []*LocatedNode{},
 		},
 		{
 			name:  "wildcard_not_an_array_index_1",
 			segs:  []*Segment{Child(Wildcard), Child(Slice(0, 5))},
 			input: []any{"x", true},
 			exp:   []any{},
+			loc:   []*LocatedNode{},
 		},
 		{
 			name: "mix_slice_keys",
@@ -645,7 +870,17 @@ func TestQuerySlice(t *testing.T) {
 				map[string]any{"x": "bo", "y": 42},
 				map[string]any{"x": true, "y": 21},
 			},
-			exp:  []any{"hi", "go", "bo", 42, true, 21, "bo", 42},
+			exp: []any{"hi", "go", "bo", 42, true, 21, "bo", 42},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Name("x")}, Node: "hi"},
+				{Path: NormalizedPath{Index(0), Name("y")}, Node: "go"},
+				{Path: NormalizedPath{Index(1), Name("x")}, Node: "bo"},
+				{Path: NormalizedPath{Index(1), Name("y")}, Node: 42},
+				{Path: NormalizedPath{Index(2), Name("x")}, Node: true},
+				{Path: NormalizedPath{Index(2), Name("y")}, Node: 21},
+				{Path: NormalizedPath{Index(1), Name("x")}, Node: "bo"},
+				{Path: NormalizedPath{Index(1), Name("y")}, Node: 42},
+			},
 			rand: true,
 		},
 		{
@@ -660,6 +895,12 @@ func TestQuerySlice(t *testing.T) {
 				map[string]any{"x": true},
 			},
 			exp: []any{"hi", "bo", true, "bo"},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Name("x")}, Node: "hi"},
+				{Path: NormalizedPath{Index(1), Name("x")}, Node: "bo"},
+				{Path: NormalizedPath{Index(2), Name("x")}, Node: true},
+				{Path: NormalizedPath{Index(1), Name("x")}, Node: "bo"},
+			},
 		},
 		{
 			name: "mix_slice_index",
@@ -673,6 +914,16 @@ func TestQuerySlice(t *testing.T) {
 				[]any{"z", true, 21},
 			},
 			exp: []any{"x", "hi", "y", "bo", "z", true, "y", "bo"},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(0), Index(1)}, Node: "hi"},
+				{Path: NormalizedPath{Index(1), Index(0)}, Node: "y"},
+				{Path: NormalizedPath{Index(1), Index(1)}, Node: "bo"},
+				{Path: NormalizedPath{Index(2), Index(0)}, Node: "z"},
+				{Path: NormalizedPath{Index(2), Index(1)}, Node: true},
+				{Path: NormalizedPath{Index(1), Index(0)}, Node: "y"},
+				{Path: NormalizedPath{Index(1), Index(1)}, Node: "bo"},
+			},
 		},
 		{
 			name: "mix_slice_nonexistent_index",
@@ -686,6 +937,12 @@ func TestQuerySlice(t *testing.T) {
 				[]any{"z", true, 21},
 			},
 			exp: []any{"x", "y", "z", "y"},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(1), Index(0)}, Node: "y"},
+				{Path: NormalizedPath{Index(2), Index(0)}, Node: "z"},
+				{Path: NormalizedPath{Index(1), Index(0)}, Node: "y"},
+			},
 		},
 		{
 			name: "slice_nonexistent_key",
@@ -695,6 +952,9 @@ func TestQuerySlice(t *testing.T) {
 				map[string]any{"z": 3, "b": 4},
 			},
 			exp: []any{1},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Name("a")}, Node: 1},
+			},
 		},
 		{
 			name: "slice_nonexistent_middle_key",
@@ -706,6 +966,10 @@ func TestQuerySlice(t *testing.T) {
 				map[string]any{"z": 3, "b": 4},
 			},
 			exp: []any{1, 5},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Name("a")}, Node: 1},
+				{Path: NormalizedPath{Index(2), Name("a")}, Node: 5},
+			},
 		},
 		{
 			name: "slice_nested_nonexistent_key",
@@ -724,6 +988,9 @@ func TestQuerySlice(t *testing.T) {
 				},
 			},
 			exp: []any{1},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Name("x"), Name("a")}, Node: 1},
+			},
 		},
 		{
 			name: "slice_nested_nonexistent_index",
@@ -742,18 +1009,32 @@ func TestQuerySlice(t *testing.T) {
 				},
 			},
 			exp: []any{2},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Name("x"), Index(1)}, Node: 2},
+			},
 		},
 		{
 			name:  "slice_neg",
 			segs:  []*Segment{Child(Slice(nil, nil, -1))},
 			input: []any{"x", true, "y", []any{1, 2}},
 			exp:   []any{[]any{1, 2}, "y", true, "x"},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(3)}, Node: []any{1, 2}},
+				{Path: NormalizedPath{Index(2)}, Node: "y"},
+				{Path: NormalizedPath{Index(1)}, Node: true},
+				{Path: NormalizedPath{Index(0)}, Node: "x"},
+			},
 		},
 		{
 			name:  "slice_5_0_neg2",
 			segs:  []*Segment{Child(Slice(5, 0, -2))},
 			input: []any{"x", true, "y", 8, 13, 25, 23, 78, 13},
 			exp:   []any{25, 8, true},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(5)}, Node: 25},
+				{Path: NormalizedPath{Index(3)}, Node: 8},
+				{Path: NormalizedPath{Index(1)}, Node: true},
+			},
 		},
 		{
 			name: "nested_neg_slices",
@@ -768,6 +1049,13 @@ func TestQuerySlice(t *testing.T) {
 				"x", true, "y",
 			},
 			exp: []any{false, 98.6, "on", true, 42},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(2), Index(2)}, Node: false},
+				{Path: NormalizedPath{Index(2), Index(1)}, Node: 98.6},
+				{Path: NormalizedPath{Index(1), Index(1)}, Node: "on"},
+				{Path: NormalizedPath{Index(0), Index(2)}, Node: true},
+				{Path: NormalizedPath{Index(0), Index(1)}, Node: 42},
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -791,38 +1079,60 @@ func TestQueryDescendants(t *testing.T) {
 			segs:  []*Segment{Descendant(Name("j"))},
 			input: json,
 			exp:   []any{1, 4},
-			rand:  true,
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("o"), Name("j")}, Node: 1},
+				{Path: NormalizedPath{Name("a"), Index(2), Index(0), Name("j")}, Node: 4},
+			},
+			rand: true,
 		},
 		{
 			name:  "un_descendant_name",
 			segs:  []*Segment{Descendant(Name("o"))},
 			input: json,
 			exp:   []any{map[string]any{"j": 1, "k": 2}},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("o")}, Node: map[string]any{"j": 1, "k": 2}},
+			},
 		},
 		{
 			name:  "nested_name",
 			segs:  []*Segment{Child(Name("o")), Descendant(Name("k"))},
 			input: json,
 			exp:   []any{2},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("o"), Name("k")}, Node: 2},
+			},
 		},
 		{
 			name:  "nested_wildcard",
 			segs:  []*Segment{Child(Name("o")), Descendant(Wildcard)},
 			input: json,
 			exp:   []any{1, 2},
-			rand:  true,
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("o"), Name("j")}, Node: 1},
+				{Path: NormalizedPath{Name("o"), Name("k")}, Node: 2},
+			},
+			rand: true,
 		},
 		{
 			name:  "single_index",
 			segs:  []*Segment{Descendant(Index(0))},
 			input: json,
 			exp:   []any{5, map[string]any{"j": 4}},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("a"), Index(0)}, Node: 5},
+				{Path: NormalizedPath{Name("a"), Index(2), Index(0)}, Node: map[string]any{"j": 4}},
+			},
 		},
 		{
 			name:  "nested_index",
 			segs:  []*Segment{Child(Name("a")), Descendant(Index(0))},
 			input: json,
 			exp:   []any{5, map[string]any{"j": 4}},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("a"), Index(0)}, Node: 5},
+				{Path: NormalizedPath{Name("a"), Index(2), Index(0)}, Node: map[string]any{"j": 4}},
+			},
 		},
 		{
 			name: "multiples",
@@ -870,6 +1180,32 @@ func TestQueryDescendants(t *testing.T) {
 					"Whatever", "OR", "98754",
 				},
 			},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("profile"), Name("name"), Name("last")}, Node: "Obama"},
+				{
+					Path: NormalizedPath{Name("profile"), Name("contacts"), Name("email"), Name("primary")},
+					Node: "foo@example.com",
+				},
+				{
+					Path: NormalizedPath{Name("profile"), Name("contacts"), Name("email"), Name("secondary")},
+					Node: "2nd@example.net",
+				},
+				{
+					Path: NormalizedPath{Name("profile"), Name("contacts"), Name("phones"), Name("primary")},
+					Node: "123456789",
+				},
+				{
+					Path: NormalizedPath{Name("profile"), Name("contacts"), Name("phones"), Name("secondary")},
+					Node: "987654321",
+				},
+				{
+					Path: NormalizedPath{Name("profile"), Name("contacts"), Name("addresses"), Name("primary")},
+					Node: []any{
+						"123 Main Street",
+						"Whatever", "OR", "98754",
+					},
+				},
+			},
 			rand: true,
 		},
 		{
@@ -877,12 +1213,18 @@ func TestQueryDescendants(t *testing.T) {
 			segs:  []*Segment{Descendant(Name("o")), Child(Name("k"))},
 			input: map[string]any{"o": map[string]any{"o": "hi", "k": 2}},
 			exp:   []any{2},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("o"), Name("k")}, Node: 2},
+			},
 		},
 		{
 			name:  "do_not_include_parent_index",
 			segs:  []*Segment{Descendant(Index(0)), Child(Index(1))},
 			input: []any{[]any{42, 98}},
 			exp:   []any{98},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0), Index(1)}, Node: 98},
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -903,11 +1245,21 @@ func TestQueryInputs(t *testing.T) {
 	a.False(q.root)
 	a.Equal([]any{"x"}, q.Select(x, y))
 	a.Equal([]any{}, q.Select(y, x))
+	a.Equal(
+		[]*LocatedNode{{Path: NormalizedPath{Name("x")}, Node: "x"}},
+		q.SelectLocated(x, y, NormalizedPath{}),
+	)
+	a.Equal([]*LocatedNode{}, q.SelectLocated(y, x, NormalizedPath{}))
 
 	// Test root.
 	q.root = true
 	a.Equal([]any{}, q.Select(x, y))
 	a.Equal([]any{"x"}, q.Select(y, x))
+	a.Equal([]*LocatedNode{}, q.SelectLocated(x, y, NormalizedPath{}))
+	a.Equal(
+		[]*LocatedNode{{Path: NormalizedPath{Name("x")}, Node: "x"}},
+		q.SelectLocated(y, x, NormalizedPath{}),
+	)
 }
 
 func TestSingularExpr(t *testing.T) {

--- a/spec/selector_test.go
+++ b/spec/selector_test.go
@@ -358,35 +358,41 @@ func TestNameSelect(t *testing.T) {
 		sel  Name
 		src  any
 		exp  []any
+		loc  []*LocatedNode
 	}{
 		{
 			name: "got_name",
 			sel:  Name("hi"),
 			src:  map[string]any{"hi": 42},
 			exp:  []any{42},
+			loc:  []*LocatedNode{{Path: NormalizedPath{Name("hi")}, Node: 42}},
 		},
 		{
 			name: "got_name_array",
 			sel:  Name("hi"),
 			src:  map[string]any{"hi": []any{42, true}},
 			exp:  []any{[]any{42, true}},
+			loc:  []*LocatedNode{{Path: NormalizedPath{Name("hi")}, Node: []any{42, true}}},
 		},
 		{
 			name: "no_name",
 			sel:  Name("hi"),
 			src:  map[string]any{"oy": []any{42, true}},
 			exp:  []any{},
+			loc:  []*LocatedNode{},
 		},
 		{
 			name: "src_array",
 			sel:  Name("hi"),
 			src:  []any{42, true},
 			exp:  []any{},
+			loc:  []*LocatedNode{},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			a.Equal(tc.exp, tc.sel.Select(tc.src, nil))
+			a.Equal(tc.loc, tc.sel.SelectLocated(tc.src, nil, NormalizedPath{}))
 		})
 	}
 }
@@ -400,53 +406,62 @@ func TestIndexSelect(t *testing.T) {
 		sel  Index
 		src  any
 		exp  []any
+		loc  []*LocatedNode
 	}{
 		{
 			name: "index_zero",
 			sel:  Index(0),
 			src:  []any{42, true, "hi"},
 			exp:  []any{42},
+			loc:  []*LocatedNode{{Path: NormalizedPath{Index(0)}, Node: 42}},
 		},
 		{
 			name: "index_two",
 			sel:  Index(2),
 			src:  []any{42, true, "hi"},
 			exp:  []any{"hi"},
+			loc:  []*LocatedNode{{Path: NormalizedPath{Index(2)}, Node: "hi"}},
 		},
 		{
 			name: "index_neg_one",
 			sel:  Index(-1),
 			src:  []any{42, true, "hi"},
 			exp:  []any{"hi"},
+			loc:  []*LocatedNode{{Path: NormalizedPath{Index(2)}, Node: "hi"}},
 		},
 		{
 			name: "index_neg_two",
 			sel:  Index(-2),
 			src:  []any{42, true, "hi"},
 			exp:  []any{true},
+			loc:  []*LocatedNode{{Path: NormalizedPath{Index(1)}, Node: true}},
 		},
 		{
 			name: "out_of_range",
 			sel:  Index(4),
 			src:  []any{42, true, "hi"},
 			exp:  []any{},
+			loc:  []*LocatedNode{},
 		},
 		{
 			name: "neg_out_of_range",
 			sel:  Index(-4),
 			src:  []any{42, true, "hi"},
 			exp:  []any{},
+			loc:  []*LocatedNode{},
 		},
 		{
 			name: "src_object",
 			sel:  Index(0),
 			src:  map[string]any{"hi": 42},
 			exp:  []any{},
+			loc:  []*LocatedNode{},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			a.Equal(tc.exp, tc.sel.Select(tc.src, nil))
+			a.Equal(tc.loc, tc.sel.SelectLocated(tc.src, nil, NormalizedPath{}))
 		})
 	}
 }
@@ -459,24 +474,42 @@ func TestWildcardSelect(t *testing.T) {
 		name string
 		src  any
 		exp  []any
+		loc  []*LocatedNode
 	}{
 		{
 			name: "object",
 			src:  map[string]any{"x": true, "y": []any{true}},
 			exp:  []any{true, []any{true}},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("x")}, Node: true},
+				{Path: NormalizedPath{Name("y")}, Node: []any{true}},
+			},
 		},
 		{
 			name: "array",
 			src:  []any{true, 42, map[string]any{"x": 6}},
 			exp:  []any{true, 42, map[string]any{"x": 6}},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0)}, Node: true},
+				{Path: NormalizedPath{Index(1)}, Node: 42},
+				{Path: NormalizedPath{Index(2)}, Node: map[string]any{"x": 6}},
+			},
+		},
+		{
+			name: "something_else",
+			src:  42,
+			exp:  []any{},
+			loc:  []*LocatedNode{},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if _, ok := tc.src.(map[string]any); ok {
 				a.ElementsMatch(tc.exp, Wildcard.Select(tc.src, nil))
+				a.ElementsMatch(tc.loc, Wildcard.SelectLocated(tc.src, nil, NormalizedPath{}))
 			} else {
 				a.Equal(tc.exp, Wildcard.Select(tc.src, nil))
+				a.Equal(tc.loc, Wildcard.SelectLocated(tc.src, nil, NormalizedPath{}))
 			}
 		})
 	}
@@ -491,83 +524,139 @@ func TestSliceSelect(t *testing.T) {
 		sel  SliceSelector
 		src  any
 		exp  []any
+		loc  []*LocatedNode
 	}{
 		{
 			name: "0_2",
 			sel:  Slice(0, 2),
 			src:  []any{42, true, "hi"},
 			exp:  []any{42, true},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0)}, Node: 42},
+				{Path: NormalizedPath{Index(1)}, Node: true},
+			},
 		},
 		{
 			name: "0_1",
 			sel:  Slice(0, 1),
 			src:  []any{[]any{42, false}, true, "hi"},
 			exp:  []any{[]any{42, false}},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0)}, Node: []any{42, false}},
+			},
 		},
 		{
 			name: "2_5",
 			sel:  Slice(2, 5),
 			src:  []any{[]any{42, false}, true, "hi", 98.6, 73, "hi", 22},
 			exp:  []any{"hi", 98.6, 73},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(2)}, Node: "hi"},
+				{Path: NormalizedPath{Index(3)}, Node: 98.6},
+				{Path: NormalizedPath{Index(4)}, Node: 73},
+			},
 		},
 		{
 			name: "2_5_over_len",
 			sel:  Slice(2, 5),
 			src:  []any{"x", true, "y"},
 			exp:  []any{"y"},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(2)}, Node: "y"},
+			},
 		},
 		{
 			name: "defaults",
 			sel:  Slice(),
 			src:  []any{"x", nil, "y", 42},
 			exp:  []any{"x", nil, "y", 42},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(1)}, Node: nil},
+				{Path: NormalizedPath{Index(2)}, Node: "y"},
+				{Path: NormalizedPath{Index(3)}, Node: 42},
+			},
 		},
 		{
 			name: "default_start",
 			sel:  Slice(nil, 3),
 			src:  []any{"x", nil, "y", 42, 98.6, 54},
 			exp:  []any{"x", nil, "y"},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(1)}, Node: nil},
+				{Path: NormalizedPath{Index(2)}, Node: "y"},
+			},
 		},
 		{
 			name: "default_end",
 			sel:  Slice(2),
 			src:  []any{"x", true, "y", 42, 98.6, 54},
 			exp:  []any{"y", 42, 98.6, 54},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(2)}, Node: "y"},
+				{Path: NormalizedPath{Index(3)}, Node: 42},
+				{Path: NormalizedPath{Index(4)}, Node: 98.6},
+				{Path: NormalizedPath{Index(5)}, Node: 54},
+			},
 		},
 		{
 			name: "step_2",
 			sel:  Slice(nil, nil, 2),
 			src:  []any{"x", true, "y", 42, 98.6, 54},
 			exp:  []any{"x", "y", 98.6},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(2)}, Node: "y"},
+				{Path: NormalizedPath{Index(4)}, Node: 98.6},
+			},
 		},
 		{
 			name: "step_3",
 			sel:  Slice(nil, nil, 3),
 			src:  []any{"x", true, "y", 42, 98.6, 54, 98, 73},
 			exp:  []any{"x", 42, 98},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0)}, Node: "x"},
+				{Path: NormalizedPath{Index(3)}, Node: 42},
+				{Path: NormalizedPath{Index(6)}, Node: 98},
+			},
 		},
 		{
 			name: "negative_step",
 			sel:  Slice(nil, nil, -1),
 			src:  []any{"x", true, "y", []any{1, 2}},
 			exp:  []any{[]any{1, 2}, "y", true, "x"},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(3)}, Node: []any{1, 2}},
+				{Path: NormalizedPath{Index(2)}, Node: "y"},
+				{Path: NormalizedPath{Index(1)}, Node: true},
+				{Path: NormalizedPath{Index(0)}, Node: "x"},
+			},
 		},
 		{
 			name: "5_0_neg2",
 			sel:  Slice(5, 0, -2),
 			src:  []any{"x", true, "y", 8, 13, 25, 23, 78, 13},
 			exp:  []any{25, 8, true},
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(5)}, Node: 25},
+				{Path: NormalizedPath{Index(3)}, Node: 8},
+				{Path: NormalizedPath{Index(1)}, Node: true},
+			},
 		},
 		{
 			name: "src_object",
 			sel:  Slice(0, 2),
 			src:  map[string]any{"hi": 42},
 			exp:  []any{},
+			loc:  []*LocatedNode{},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			a.Equal(tc.exp, tc.sel.Select(tc.src, nil))
+			a.Equal(tc.loc, tc.sel.SelectLocated(tc.src, nil, NormalizedPath{}))
 		})
 	}
 }
@@ -582,6 +671,7 @@ func TestFilterSelector(t *testing.T) {
 		root    any
 		current any
 		exp     []any
+		loc     []*LocatedNode
 		str     string
 		rand    bool
 	}{
@@ -589,6 +679,7 @@ func TestFilterSelector(t *testing.T) {
 			name:   "no_filter",
 			filter: Filter(LogicalOr{}),
 			exp:    []any{},
+			loc:    []*LocatedNode{},
 			str:    "?",
 		},
 		{
@@ -599,7 +690,10 @@ func TestFilterSelector(t *testing.T) {
 			root:    []any{42, true, "hi"},
 			current: map[string]any{"x": 2},
 			exp:     []any{2},
-			str:     `?$[0]`,
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("x")}, Node: 2},
+			},
+			str: `?$[0]`,
 		},
 		{
 			name: "array_root_false",
@@ -609,6 +703,7 @@ func TestFilterSelector(t *testing.T) {
 			root:    []any{42, true, "hi"},
 			current: map[string]any{"x": 2},
 			exp:     []any{},
+			loc:     []*LocatedNode{},
 			str:     `?$[4]`,
 		},
 		{
@@ -619,8 +714,12 @@ func TestFilterSelector(t *testing.T) {
 			root:    map[string]any{"x": 42, "y": "hi"},
 			current: map[string]any{"a": 2, "b": 3},
 			exp:     []any{2, 3},
-			str:     `?$["y"]`,
-			rand:    true,
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Name("a")}, Node: 2},
+				{Path: NormalizedPath{Name("b")}, Node: 3},
+			},
+			str:  `?$["y"]`,
+			rand: true,
 		},
 		{
 			name: "object_root_false",
@@ -630,6 +729,7 @@ func TestFilterSelector(t *testing.T) {
 			root:    map[string]any{"x": 42, "y": "hi"},
 			current: map[string]any{"a": 2, "b": 3},
 			exp:     []any{},
+			loc:     []*LocatedNode{},
 			str:     `?$["z"]`,
 			rand:    true,
 		},
@@ -640,7 +740,10 @@ func TestFilterSelector(t *testing.T) {
 			}}}),
 			current: []any{[]any{42}},
 			exp:     []any{[]any{42}},
-			str:     `?@[0]`,
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0)}, Node: []any{42}},
+			},
+			str: `?@[0]`,
 		},
 		{
 			name: "array_current_false",
@@ -649,6 +752,7 @@ func TestFilterSelector(t *testing.T) {
 			}}}),
 			current: []any{[]any{42}},
 			exp:     []any{},
+			loc:     []*LocatedNode{},
 			str:     `?@[1]`,
 		},
 		{
@@ -658,7 +762,10 @@ func TestFilterSelector(t *testing.T) {
 			}}}),
 			current: []any{map[string]any{"x": 42}},
 			exp:     []any{map[string]any{"x": 42}},
-			str:     `?@["x"]`,
+			loc: []*LocatedNode{
+				{Path: NormalizedPath{Index(0)}, Node: map[string]any{"x": 42}},
+			},
+			str: `?@["x"]`,
 		},
 		{
 			name: "object_current_false",
@@ -667,6 +774,7 @@ func TestFilterSelector(t *testing.T) {
 			}}}),
 			current: []any{map[string]any{"x": 42}},
 			exp:     []any{},
+			loc:     []*LocatedNode{},
 			str:     `?@["y"]`,
 		},
 	} {
@@ -674,8 +782,10 @@ func TestFilterSelector(t *testing.T) {
 			t.Parallel()
 			if tc.rand {
 				a.ElementsMatch(tc.exp, tc.filter.Select(tc.current, tc.root))
+				a.ElementsMatch(tc.loc, tc.filter.SelectLocated(tc.current, tc.root, NormalizedPath{}))
 			} else {
 				a.Equal(tc.exp, tc.filter.Select(tc.current, tc.root))
+				a.Equal(tc.loc, tc.filter.SelectLocated(tc.current, tc.root, NormalizedPath{}))
 			}
 			a.Equal(tc.str, tc.filter.String())
 			a.Equal(tc.str, bufString(tc.filter))


### PR DESCRIPTION
`SelectLocated` works just like `Select`, but returns a slice of `LocatedNode`s that contain the same nodes as those returned by `Select` paired with `NormalizedPath`s that uniquely identify their locations within the JSON query argument. [RFC 9535 section 2.7] defines normalized paths, including their string representation, implemented here. The design largely borrows from [serde_json_path]'s [`query_located`] method.

Add `SelectLocated` to the `Selector` interface and implement it in each selector, segments, and queries. The implementation is quite similar to `Select`, but takes care to properly construct `NormalizedPath`s for each selected node. Update all tests to validate both methods.

The new `NormalSelector` interface defines normalized path selectors, of which there are two: `Index` and `Name`. `Name`, in particular, attempts to hew to the RFC's stringification grammar as closely as possible.

Also: upgrade golangci-lint to v1.62.2 and update its configuration

[RFC 9535 section 2.7]: https://www.rfc-editor.org/rfc/rfc9535#section-2.7
[serde_json_path]: https://github.com/hiltontj/serde_json_path
[`query_located`]: https://docs.rs/serde_json_path/latest/serde_json_path/struct.JsonPath.html#method.query_located