### PR TITLE
Simplify FuncType, conversion validation, names

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -35,7 +35,7 @@ linters:
         - empty
         - stdlib
         - generic
-        - spec\.JSONPathValue
+        - spec\.PathValue
         - spec\.FuncExprArg
         - spec\.Selector
         - spec\.BasicExpr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,17 @@ All notable changes to this project will be documented in this file. It uses the
 
 ### ⚡ Improvements
 
-*   Made significant changes to the `spec` package toward public stability,
-    usability, and greater comprehension. The names of things are more
-    consistent, the APIs more legible and user-friendly. See [PR #14] for
-    details.
+*   Significantly refactored the `spec` package toward greater stability,
+    usability, and increased comprehensibility. The names of things are more
+    consistent, the APIs more legible and user-friendly. Quite a few types
+    were renamed or merged.
 *   Added support for [json.Number] values to complement the existing support
     for Go core numeric types. This should allow for transparent handling of
     values marshaled with [json.Decoder.UseNumber] enabled.
+*   Moved the function extension types from the `registry` to the `spec`
+    package, simplifying `registry` and the handling of function extensions,
+    without changing the interface for using a registry or adding extensions
+    to it.
 
 ### 📚 Documentation
 
@@ -26,7 +30,8 @@ All notable changes to this project will be documented in this file. It uses the
     and complete lists of interface implementations and examples for each
     significant type. See [PR #14] for details.
 *   Removed the "Package Stability" statement from the README, as all packages
-    are considered stable.
+    are considered stable or else potentially unstable types in the `spec`
+    package have been labeled as such.
 *   Fixed links and typos in the main package documentation, and moved the
     registry example under `WithRegistry`.
 

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -201,7 +201,7 @@ func TestParseFilter(t *testing.T) {
 		"__true",
 		spec.FuncLogical,
 		func([]spec.FuncExprArg) error { return nil },
-		func([]spec.JSONPathValue) spec.JSONPathValue {
+		func([]spec.PathValue) spec.PathValue {
 			return spec.LogicalTrue
 		},
 	)

--- a/path_example_test.go
+++ b/path_example_test.go
@@ -275,7 +275,7 @@ func validateFirstArgs(args []spec.FuncExprArg) error {
 		return fmt.Errorf("expected 1 argument but found %v", len(args))
 	}
 
-	if !args[0].ResultType().ConvertsToNodes() {
+	if !args[0].ConvertsTo(spec.FuncNodes) {
 		return errors.New("cannot convert argument to nodes")
 	}
 
@@ -285,7 +285,7 @@ func validateFirstArgs(args []spec.FuncExprArg) error {
 // firstFunc defines the custom first() JSONPath function. It converts its
 // single argument to a [spec.NodesType] value and returns a [spec.ValueType]
 // that contains the first node. If there are no nodes it returns nil.
-func firstFunc(jv []spec.JSONPathValue) spec.JSONPathValue {
+func firstFunc(jv []spec.PathValue) spec.PathValue {
 	nodes := spec.NodesFrom(jv[0])
 	if len(nodes) == 0 {
 		return nil

--- a/registry/funcs.go
+++ b/registry/funcs.go
@@ -13,13 +13,12 @@ import (
 // checkLengthArgs checks the argument expressions to length() and returns an
 // error if there is not exactly one expression that results in a compatible
 // [spec.FuncValue] value.
-func checkLengthArgs(fea []spec.FuncExprArg) error {
-	if len(fea) != 1 {
-		return fmt.Errorf("expected 1 argument but found %v", len(fea))
+func checkLengthArgs(args []spec.FuncExprArg) error {
+	if len(args) != 1 {
+		return fmt.Errorf("expected 1 argument but found %v", len(args))
 	}
 
-	kind := fea[0].ResultType()
-	if !kind.ConvertsToValue() {
+	if !args[0].ConvertsTo(spec.FuncValue) {
 		return errors.New("cannot convert argument to Value")
 	}
 
@@ -37,7 +36,7 @@ func checkLengthArgs(fea []spec.FuncExprArg) error {
 //   - If jv[0] is an map[string]any, the result is the number of members in
 //     the map.
 //   - For any other value, the result is nil.
-func lengthFunc(jv []spec.JSONPathValue) spec.JSONPathValue {
+func lengthFunc(jv []spec.PathValue) spec.PathValue {
 	v := spec.ValueFrom(jv[0])
 	if v == nil {
 		return nil
@@ -58,13 +57,12 @@ func lengthFunc(jv []spec.JSONPathValue) spec.JSONPathValue {
 // checkCountArgs checks the argument expressions to count() and returns an
 // error if there is not exactly one expression that results in a
 // [spec.FuncNodes]-compatible value.
-func checkCountArgs(fea []spec.FuncExprArg) error {
-	if len(fea) != 1 {
-		return fmt.Errorf("expected 1 argument but found %v", len(fea))
+func checkCountArgs(args []spec.FuncExprArg) error {
+	if len(args) != 1 {
+		return fmt.Errorf("expected 1 argument but found %v", len(args))
 	}
 
-	kind := fea[0].ResultType()
-	if !kind.ConvertsToNodes() {
+	if !args[0].ConvertsTo(spec.FuncNodes) {
 		return errors.New("cannot convert argument to Nodes")
 	}
 
@@ -75,20 +73,19 @@ func checkCountArgs(fea []spec.FuncExprArg) error {
 // a ValueType containing an unsigned integer for the number of nodes in
 // jv[0]. Panics if jv[0] doesn't exist or is not convertible to
 // [spec.NodesType].
-func countFunc(jv []spec.JSONPathValue) spec.JSONPathValue {
+func countFunc(jv []spec.PathValue) spec.PathValue {
 	return spec.Value(len(spec.NodesFrom(jv[0])))
 }
 
 // checkValueArgs checks the argument expressions to value() and returns an
 // error if there is not exactly one expression that results in a
 // [spec.FuncNodes]-compatible value.
-func checkValueArgs(fea []spec.FuncExprArg) error {
-	if len(fea) != 1 {
-		return fmt.Errorf("expected 1 argument but found %v", len(fea))
+func checkValueArgs(args []spec.FuncExprArg) error {
+	if len(args) != 1 {
+		return fmt.Errorf("expected 1 argument but found %v", len(args))
 	}
 
-	kind := fea[0].ResultType()
-	if !kind.ConvertsToNodes() {
+	if !args[0].ConvertsTo(spec.FuncNodes) {
 		return errors.New("cannot convert argument to Nodes")
 	}
 
@@ -100,7 +97,7 @@ func checkValueArgs(fea []spec.FuncExprArg) error {
 //
 //   - If jv[0] contains a single node, the result is the value of the node.
 //   - If jv[0] is empty or contains multiple nodes, the result is nil.
-func valueFunc(jv []spec.JSONPathValue) spec.JSONPathValue {
+func valueFunc(jv []spec.PathValue) spec.PathValue {
 	nodes := spec.NodesFrom(jv[0])
 	if len(nodes) == 1 {
 		return spec.Value(nodes[0])
@@ -111,15 +108,14 @@ func valueFunc(jv []spec.JSONPathValue) spec.JSONPathValue {
 // checkMatchArgs checks the argument expressions to match() and returns an
 // error if there are not exactly two expressions that result in compatible
 // [spec.FuncValue] values.
-func checkMatchArgs(fea []spec.FuncExprArg) error {
+func checkMatchArgs(args []spec.FuncExprArg) error {
 	const matchArgLen = 2
-	if len(fea) != matchArgLen {
-		return fmt.Errorf("expected 2 arguments but found %v", len(fea))
+	if len(args) != matchArgLen {
+		return fmt.Errorf("expected 2 arguments but found %v", len(args))
 	}
 
-	for i, arg := range fea {
-		kind := arg.ResultType()
-		if !kind.ConvertsToValue() {
+	for i, arg := range args {
+		if !arg.ConvertsTo(spec.FuncValue) {
 			return fmt.Errorf("cannot convert argument %v to Value", i+1)
 		}
 	}
@@ -132,11 +128,11 @@ func checkMatchArgs(fea []spec.FuncExprArg) error {
 // implied \A and \z anchors and used to match the first, returning LogicalTrue for
 // a match and LogicalFalse for no match. Returns LogicalFalse if either jv value
 // is not a string or if jv[1] fails to compile.
-func matchFunc(jv []spec.JSONPathValue) spec.JSONPathValue {
+func matchFunc(jv []spec.PathValue) spec.PathValue {
 	if v, ok := spec.ValueFrom(jv[0]).Value().(string); ok {
 		if r, ok := spec.ValueFrom(jv[1]).Value().(string); ok {
 			if rc := compileRegex(`\A` + r + `\z`); rc != nil {
-				return spec.LogicalFrom(rc.MatchString(v))
+				return spec.Logical(rc.MatchString(v))
 			}
 		}
 	}
@@ -146,15 +142,14 @@ func matchFunc(jv []spec.JSONPathValue) spec.JSONPathValue {
 // checkSearchArgs checks the argument expressions to search() and returns an
 // error if there are not exactly two expressions that result in compatible
 // [spec.FuncValue] values.
-func checkSearchArgs(fea []spec.FuncExprArg) error {
+func checkSearchArgs(args []spec.FuncExprArg) error {
 	const searchArgLen = 2
-	if len(fea) != searchArgLen {
-		return fmt.Errorf("expected 2 arguments but found %v", len(fea))
+	if len(args) != searchArgLen {
+		return fmt.Errorf("expected 2 arguments but found %v", len(args))
 	}
 
-	for i, arg := range fea {
-		kind := arg.ResultType()
-		if !kind.ConvertsToValue() {
+	for i, arg := range args {
+		if !arg.ConvertsTo(spec.FuncValue) {
 			return fmt.Errorf("cannot convert argument %v to Value", i+1)
 		}
 	}
@@ -167,11 +162,11 @@ func checkSearchArgs(fea []spec.FuncExprArg) error {
 // to match the former, returning LogicalTrue for a match and LogicalFalse for no
 // match. Returns LogicalFalse if either value is not a string, or if jv[1]
 // fails to compile.
-func searchFunc(jv []spec.JSONPathValue) spec.JSONPathValue {
+func searchFunc(jv []spec.PathValue) spec.PathValue {
 	if val, ok := spec.ValueFrom(jv[0]).Value().(string); ok {
 		if r, ok := spec.ValueFrom(jv[1]).Value().(string); ok {
 			if rc := compileRegex(r); rc != nil {
-				return spec.LogicalFrom(rc.MatchString(val))
+				return spec.Logical(rc.MatchString(val))
 			}
 		}
 	}

--- a/registry/funcs_test.go
+++ b/registry/funcs_test.go
@@ -15,58 +15,58 @@ func TestLengthFunc(t *testing.T) {
 
 	for _, tc := range []struct {
 		name string
-		vals []spec.JSONPathValue
+		vals []spec.PathValue
 		exp  int
 		err  string
 	}{
 		{
 			name: "empty_string",
-			vals: []spec.JSONPathValue{spec.Value("")},
+			vals: []spec.PathValue{spec.Value("")},
 			exp:  0,
 		},
 		{
 			name: "ascii_string",
-			vals: []spec.JSONPathValue{spec.Value("abc def")},
+			vals: []spec.PathValue{spec.Value("abc def")},
 			exp:  7,
 		},
 		{
 			name: "unicode_string",
-			vals: []spec.JSONPathValue{spec.Value("foö")},
+			vals: []spec.PathValue{spec.Value("foö")},
 			exp:  3,
 		},
 		{
 			name: "emoji_string",
-			vals: []spec.JSONPathValue{spec.Value("Hi 👋🏻")},
+			vals: []spec.PathValue{spec.Value("Hi 👋🏻")},
 			exp:  5,
 		},
 		{
 			name: "empty_array",
-			vals: []spec.JSONPathValue{spec.Value([]any{})},
+			vals: []spec.PathValue{spec.Value([]any{})},
 			exp:  0,
 		},
 		{
 			name: "array",
-			vals: []spec.JSONPathValue{spec.Value([]any{1, 2, 3, 4, 5})},
+			vals: []spec.PathValue{spec.Value([]any{1, 2, 3, 4, 5})},
 			exp:  5,
 		},
 		{
 			name: "nested_array",
-			vals: []spec.JSONPathValue{spec.Value([]any{1, 2, 3, "x", []any{456, 67}, true})},
+			vals: []spec.PathValue{spec.Value([]any{1, 2, 3, "x", []any{456, 67}, true})},
 			exp:  6,
 		},
 		{
 			name: "empty_object",
-			vals: []spec.JSONPathValue{spec.Value(map[string]any{})},
+			vals: []spec.PathValue{spec.Value(map[string]any{})},
 			exp:  0,
 		},
 		{
 			name: "object",
-			vals: []spec.JSONPathValue{spec.Value(map[string]any{"x": 1, "y": 0, "z": 2})},
+			vals: []spec.PathValue{spec.Value(map[string]any{"x": 1, "y": 0, "z": 2})},
 			exp:  3,
 		},
 		{
 			name: "nested_object",
-			vals: []spec.JSONPathValue{spec.Value(map[string]any{
+			vals: []spec.PathValue{spec.Value(map[string]any{
 				"x": 1,
 				"y": 0,
 				"z": []any{1, 2},
@@ -76,28 +76,28 @@ func TestLengthFunc(t *testing.T) {
 		},
 		{
 			name: "integer",
-			vals: []spec.JSONPathValue{spec.Value(42)},
+			vals: []spec.PathValue{spec.Value(42)},
 			exp:  -1,
 		},
 		{
 			name: "bool",
-			vals: []spec.JSONPathValue{spec.Value(true)},
+			vals: []spec.PathValue{spec.Value(true)},
 			exp:  -1,
 		},
 		{
 			name: "null",
-			vals: []spec.JSONPathValue{spec.Value(nil)},
+			vals: []spec.PathValue{spec.Value(nil)},
 			exp:  -1,
 		},
 		{
 			name: "nil",
-			vals: []spec.JSONPathValue{nil},
+			vals: []spec.PathValue{nil},
 			exp:  -1,
 		},
 		{
 			name: "not_value",
-			vals: []spec.JSONPathValue{spec.LogicalFalse},
-			err:  "unexpected argument of type spec.LogicalType",
+			vals: []spec.PathValue{spec.LogicalFalse},
+			err:  "cannot convert LogicalType to ValueType",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -153,16 +153,14 @@ func TestCheckSingularFuncArgs(t *testing.T) {
 		},
 		{
 			name: "nodes_query",
-			expr: []spec.FuncExprArg{spec.NodesQuery(
+			expr: []spec.FuncExprArg{
 				spec.Query(true, spec.Child(spec.Name("x"))),
-			)},
+			},
 		},
 		{
 			name: "logical_func_expr",
 			expr: []spec.FuncExprArg{spec.Function(reg.Get("match"),
-				spec.NodesQuery(
-					spec.Query(true, spec.Child(spec.Name("x"))),
-				),
+				spec.Query(true, spec.Child(spec.Name("x"))),
 				spec.Literal("hi"),
 			)},
 			lengthErr: "cannot convert argument to Value",
@@ -261,7 +259,7 @@ func TestCheckRegexFuncArgs(t *testing.T) {
 		{
 			name: "nodes_query_1",
 			expr: []spec.FuncExprArg{
-				spec.NodesQuery(spec.Query(true, spec.Child(spec.Name("x")))),
+				spec.Query(true, spec.Child(spec.Name("x"))),
 				spec.Literal("hi"),
 			},
 		},
@@ -269,7 +267,7 @@ func TestCheckRegexFuncArgs(t *testing.T) {
 			name: "nodes_query_2",
 			expr: []spec.FuncExprArg{
 				spec.Literal("hi"),
-				spec.NodesQuery(spec.Query(true, spec.Child(spec.Name("x")))),
+				spec.Query(true, spec.Child(spec.Name("x"))),
 			},
 		},
 		{
@@ -277,7 +275,7 @@ func TestCheckRegexFuncArgs(t *testing.T) {
 			expr: []spec.FuncExprArg{
 				spec.Function(
 					reg.Get("match"),
-					spec.NodesQuery(spec.Query(true, spec.Child(spec.Name("x")))),
+					spec.Query(true, spec.Child(spec.Name("x"))),
 					spec.Literal("hi"),
 				),
 				spec.Literal("hi"),
@@ -290,7 +288,7 @@ func TestCheckRegexFuncArgs(t *testing.T) {
 				spec.Literal("hi"),
 				spec.Function(
 					reg.Get("match"),
-					spec.NodesQuery(spec.Query(true, spec.Child(spec.Name("x")))),
+					spec.Query(true, spec.Child(spec.Name("x"))),
 					spec.Literal("hi"),
 				),
 			},
@@ -324,14 +322,14 @@ func TestCountFunc(t *testing.T) {
 
 	for _, tc := range []struct {
 		name string
-		vals []spec.JSONPathValue
+		vals []spec.PathValue
 		exp  int
 		err  string
 	}{
-		{"empty", []spec.JSONPathValue{spec.Nodes()}, 0, ""},
-		{"one", []spec.JSONPathValue{spec.Nodes(1)}, 1, ""},
-		{"three", []spec.JSONPathValue{spec.Nodes(1, true, nil)}, 3, ""},
-		{"not_nodes", []spec.JSONPathValue{spec.LogicalTrue}, 0, "unexpected argument of type spec.LogicalType"},
+		{"empty", []spec.PathValue{spec.Nodes()}, 0, ""},
+		{"one", []spec.PathValue{spec.Nodes(1)}, 1, ""},
+		{"three", []spec.PathValue{spec.Nodes(1, true, nil)}, 3, ""},
+		{"not_nodes", []spec.PathValue{spec.LogicalTrue}, 0, "cannot convert LogicalType to NodesType"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -355,16 +353,16 @@ func TestValueFunc(t *testing.T) {
 
 	for _, tc := range []struct {
 		name string
-		vals []spec.JSONPathValue
-		exp  spec.JSONPathValue
+		vals []spec.PathValue
+		exp  spec.PathValue
 		err  string
 	}{
-		{"empty", []spec.JSONPathValue{spec.Nodes()}, nil, ""},
-		{"one_int", []spec.JSONPathValue{spec.Nodes(1)}, spec.Value(1), ""},
-		{"one_null", []spec.JSONPathValue{spec.Nodes(nil)}, spec.Value(nil), ""},
-		{"one_string", []spec.JSONPathValue{spec.Nodes("x")}, spec.Value("x"), ""},
-		{"three", []spec.JSONPathValue{spec.Nodes(1, true, nil)}, nil, ""},
-		{"not_nodes", []spec.JSONPathValue{spec.LogicalFalse}, nil, "unexpected argument of type spec.LogicalType"},
+		{"empty", []spec.PathValue{spec.Nodes()}, nil, ""},
+		{"one_int", []spec.PathValue{spec.Nodes(1)}, spec.Value(1), ""},
+		{"one_null", []spec.PathValue{spec.Nodes(nil)}, spec.Value(nil), ""},
+		{"one_string", []spec.PathValue{spec.Nodes("x")}, spec.Value("x"), ""},
+		{"three", []spec.PathValue{spec.Nodes(1, true, nil)}, nil, ""},
+		{"not_nodes", []spec.PathValue{spec.LogicalFalse}, nil, "cannot convert LogicalType to NodesType"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -440,8 +438,8 @@ func TestRegexFuncs(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			a.Equal(spec.LogicalFrom(tc.match), matchFunc([]spec.JSONPathValue{tc.input, tc.regex}))
-			a.Equal(spec.LogicalFrom(tc.search), searchFunc([]spec.JSONPathValue{tc.input, tc.regex}))
+			a.Equal(spec.Logical(tc.match), matchFunc([]spec.PathValue{tc.input, tc.regex}))
+			a.Equal(spec.Logical(tc.search), searchFunc([]spec.PathValue{tc.input, tc.regex}))
 		})
 	}
 }
@@ -452,33 +450,33 @@ func TestExecRegexFuncs(t *testing.T) {
 
 	for _, tc := range []struct {
 		name   string
-		vals   []spec.JSONPathValue
+		vals   []spec.PathValue
 		match  bool
 		search bool
 		err    string
 	}{
 		{
 			name:   "dot",
-			vals:   []spec.JSONPathValue{spec.Value("x"), spec.Value("x")},
+			vals:   []spec.PathValue{spec.Value("x"), spec.Value("x")},
 			match:  true,
 			search: true,
 		},
 		{
 			name: "first_not_value",
-			vals: []spec.JSONPathValue{spec.Nodes(), spec.Value("x")},
-			err:  "unexpected argument of type spec.NodesType",
+			vals: []spec.PathValue{spec.Nodes(), spec.Value("x")},
+			err:  "cannot convert NodesType to ValueType",
 		},
 		{
 			name: "second_not_value",
-			vals: []spec.JSONPathValue{spec.Value("x"), spec.LogicalFalse},
-			err:  "unexpected argument of type spec.LogicalType",
+			vals: []spec.PathValue{spec.Value("x"), spec.LogicalFalse},
+			err:  "cannot convert LogicalType to ValueType",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if tc.err == "" {
-				a.Equal(matchFunc(tc.vals), spec.LogicalFrom(tc.match))
-				a.Equal(searchFunc(tc.vals), spec.LogicalFrom(tc.search))
+				a.Equal(matchFunc(tc.vals), spec.Logical(tc.match))
+				a.Equal(searchFunc(tc.vals), spec.Logical(tc.search))
 			} else {
 				a.PanicsWithValue(tc.err, func() { matchFunc(tc.vals) })
 				a.PanicsWithValue(tc.err, func() { searchFunc(tc.vals) })

--- a/registry/registry_example_test.go
+++ b/registry/registry_example_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/theory/jsonpath/spec"
 )
 
-// Create and registry a custom JSONPath expression, first(), that returns the
-// first node in a list of nodes passed to it. See
-// [github.com/theory/jsonpath.Parser] for a more complete example.
+// Create and register a JSONPath extension function, first(), that returns
+// the first node in a list of nodes passed to it. See
+// [github.com/theory/jsonpath.WithRegistry] for a more complete example.
 func Example() {
 	reg := registry.New()
 	err := reg.Register(
@@ -23,29 +23,29 @@ func Example() {
 	if err != nil {
 		log.Fatalf("Error %v", err)
 	}
-	fmt.Printf("%v\n", reg.Get("first").ResultType())
+	fmt.Printf("%v\n", reg.Get("first").ReturnType())
 	// Output: Value
 }
 
 // validateFirstArgs validates that a single argument is passed to the first()
-// function, and that it can be converted to [spec.FuncNodes], so that first()
-// can return the first node. It's called by the parser.
-func validateFirstArgs(fea []spec.FuncExprArg) error {
-	if len(fea) != 1 {
-		return fmt.Errorf("expected 1 argument but found %v", len(fea))
+// extension function, and that it can be converted to [spec.NodesType], so
+// that first() can return the first node. It's called by the parser.
+func validateFirstArgs(args []spec.FuncExprArg) error {
+	if len(args) != 1 {
+		return fmt.Errorf("expected 1 argument but found %v", len(args))
 	}
 
-	if !fea[0].ResultType().ConvertsToNodes() {
+	if !args[0].ConvertsTo(spec.FuncNodes) {
 		return errors.New("cannot convert argument to Nodes")
 	}
 
 	return nil
 }
 
-// firstFunc defines the custom first() JSONPath function. It converts its
-// single argument to a [spec.NodesType] value and returns a [*spec.ValueType]
+// firstFunc defines the first() JSONPath extension function. It converts its
+// single argument to a [spec.NodesType] value and returns a [spec.ValueType]
 // that contains the first node. If there are no nodes it returns nil.
-func firstFunc(jv []spec.JSONPathValue) spec.JSONPathValue {
+func firstFunc(jv []spec.PathValue) spec.PathValue {
 	nodes := spec.NodesFrom(jv[0])
 	if len(nodes) == 0 {
 		return nil

--- a/spec/filter.go
+++ b/spec/filter.go
@@ -116,14 +116,18 @@ func (lo LogicalOr) writeTo(buf *strings.Builder) {
 // evaluate evaluates lo and returns LogicalTrue when it returns true and
 // LogicalFalse when it returns false. Defined by the [FuncExprArg]
 // interface.
-func (lo LogicalOr) evaluate(current, root any) JSONPathValue {
-	return LogicalFrom(lo.testFilter(current, root))
+func (lo LogicalOr) evaluate(current, root any) PathValue {
+	return Logical(lo.testFilter(current, root))
 }
 
 // ResultType returns [FuncLogical]. Defined by the [FuncExprArg] interface.
 func (lo LogicalOr) ResultType() FuncType {
 	return FuncLogical
 }
+
+// ConvertsTo returns true if the result of the [LogicalOr] can be converted
+// to ft.
+func (LogicalOr) ConvertsTo(ft FuncType) bool { return ft == FuncLogical }
 
 // ParenExpr represents a parenthesized expression that groups the elements of
 // a [LogicalOr]. Interfaces implemented (via the underlying [LogicalOr]):

--- a/spec/filter_test.go
+++ b/spec/filter_test.go
@@ -179,8 +179,11 @@ func TestLogicalOrExpr(t *testing.T) {
 			orExpr := LogicalOr(tc.expr)
 			a.Equal(FuncLogical, orExpr.ResultType())
 			a.Equal(tc.exp, orExpr.testFilter(tc.current, tc.root))
-			a.Equal(LogicalFrom(tc.exp), orExpr.evaluate(tc.current, tc.root))
+			a.Equal(Logical(tc.exp), orExpr.evaluate(tc.current, tc.root))
 			a.Equal(tc.str, bufString(orExpr))
+			a.True(orExpr.ConvertsTo(FuncLogical))
+			a.False(orExpr.ConvertsTo(FuncValue))
+			a.False(orExpr.ConvertsTo(FuncNodes))
 
 			// Test ParenExpr.
 			pExpr := Paren(orExpr...)

--- a/spec/function_string.go
+++ b/spec/function_string.go
@@ -8,16 +8,14 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[FuncLiteral-1]
-	_ = x[FuncSingularQuery-2]
-	_ = x[FuncValue-3]
-	_ = x[FuncNodes-4]
-	_ = x[FuncLogical-5]
+	_ = x[FuncValue-1]
+	_ = x[FuncNodes-2]
+	_ = x[FuncLogical-3]
 }
 
-const _FuncType_name = "LiteralSingularQueryValueNodesLogical"
+const _FuncType_name = "ValueNodesLogical"
 
-var _FuncType_index = [...]uint8{0, 7, 20, 25, 30, 37}
+var _FuncType_index = [...]uint8{0, 5, 10, 17}
 
 func (i FuncType) String() string {
 	i -= 1

--- a/spec/op.go
+++ b/spec/op.go
@@ -38,7 +38,7 @@ const (
 type CompVal interface {
 	stringWriter
 	// asValue returns the value to be compared.
-	asValue(current, root any) JSONPathValue
+	asValue(current, root any) PathValue
 }
 
 // ComparisonExpr is a filter expression that compares two values, which
@@ -100,7 +100,7 @@ func (ce *ComparisonExpr) testFilter(current, root any) bool {
 // equalTo returns true if left and right are nils, or if both are [ValueType]
 // values and [valueEqualTo] returns true for their underlying values.
 // Otherwise it returns false.
-func equalTo(left, right JSONPathValue) bool {
+func equalTo(left, right PathValue) bool {
 	switch left := left.(type) {
 	case *ValueType:
 		if right, ok := right.(*ValueType); ok {
@@ -163,7 +163,7 @@ func valueEqualTo(left, right any) bool {
 // lessThan returns true if left and right are both ValueTypes and
 // [valueLessThan] returns true for their underlying values. Otherwise it
 // returns false.
-func lessThan(left, right JSONPathValue) bool {
+func lessThan(left, right PathValue) bool {
 	if left, ok := left.(*ValueType); ok {
 		if right, ok := right.(*ValueType); ok {
 			return valueLessThan(left.any, right.any)
@@ -173,7 +173,7 @@ func lessThan(left, right JSONPathValue) bool {
 }
 
 // sameType returns true if left and right resolve to the same JSON data type.
-func sameType(left, right JSONPathValue) bool {
+func sameType(left, right PathValue) bool {
 	switch left := left.(type) {
 	case NodesType:
 		if len(left) == 1 {

--- a/spec/op_test.go
+++ b/spec/op_test.go
@@ -186,8 +186,8 @@ func TestSameType(t *testing.T) {
 
 	for _, tc := range []struct {
 		name  string
-		left  JSONPathValue
-		right JSONPathValue
+		left  PathValue
+		right PathValue
 		exp   bool
 	}{
 		{"int_nodes", Nodes(1), Nodes(0), true},
@@ -374,11 +374,11 @@ func TestComparisonExpr(t *testing.T) {
 		{
 			name: "func_strings_gt",
 			left: &FuncExpr{
-				args: []FuncExprArg{NodesQuery(Query(false, Child(Name("y"))))},
+				args: []FuncExprArg{Query(false, Child(Name("y")))},
 				fn:   newValueFunc(42),
 			},
 			right: &FuncExpr{
-				args: []FuncExprArg{NodesQuery(Query(false, Child(Name("x"))))},
+				args: []FuncExprArg{Query(false, Child(Name("x")))},
 				fn:   newValueFunc(41),
 			},
 			current: map[string]any{"x": "x", "y": "y"},

--- a/spec/selector.go
+++ b/spec/selector.go
@@ -453,7 +453,7 @@ type FilterSelector struct {
 	LogicalOr
 }
 
-// Filter returns a new Filter selector that ORs the evaluation of each expr.
+// Filter returns a new [FilterSelector] that ORs the evaluation of each expr.
 func Filter(expr ...LogicalAnd) *FilterSelector {
 	return &FilterSelector{LogicalOr: expr}
 }

--- a/spec/spec_example_test.go
+++ b/spec/spec_example_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/theory/jsonpath"
 	"github.com/theory/jsonpath/registry"
@@ -188,60 +187,12 @@ func ExampleNonExistExpr() {
 	// Output: ?!@["x"]
 }
 
-// Construct a path expression as a function argument.
-func ExampleNodesQueryExpr() {
-	reg := registry.New()
-	fnExpr := spec.Function(
-		reg.Get("length"),
-		spec.NodesQuery(
-			spec.Query(false, spec.Child(spec.Index(0))),
-		),
-	)
-	fmt.Printf("%v\n", fnExpr)
-	// Output: length(@[0])
-}
-
-// Each [spec.FuncType] converted to one of the spec-standard function types,
-// [spec.ValueType], [spec.NodesType], or [spec.LogicalType].
-func ExampleFuncType() {
-	fmt.Println("FuncType       Converts To FuncTypes")
-	fmt.Println("-------------- ---------------------")
-	for _, at := range []spec.FuncType{
-		spec.FuncLiteral,
-		spec.FuncSingularQuery,
-		spec.FuncValue,
-		spec.FuncNodes,
-		spec.FuncLogical,
-	} {
-		to := []string{}
-		if at.ConvertsToValue() {
-			to = append(to, "Value")
-		}
-		if at.ConvertsToLogical() {
-			to = append(to, "Logical")
-		}
-		if at.ConvertsToNodes() {
-			to = append(to, "Nodes")
-		}
-
-		fmt.Printf("%-15v %v\n", at, strings.Join(to, ", "))
-	}
-	// Output:
-	// FuncType       Converts To FuncTypes
-	// -------------- ---------------------
-	// Literal         Value
-	// SingularQuery   Value, Logical, Nodes
-	// Value           Value
-	// Nodes           Logical, Nodes
-	// Logical         Logical
-}
-
-// Print the [spec.FuncType] for each [spec.JSONPathValue]
+// Print the [spec.FuncType] for each [spec.PathValue]
 // implementation.
-func ExampleJSONPathValue() {
+func ExamplePathValue() {
 	fmt.Printf("Implementation    FuncType\n")
 	fmt.Printf("----------------- --------\n")
-	for _, jv := range []spec.JSONPathValue{
+	for _, jv := range []spec.PathValue{
 		spec.Value(nil),
 		spec.Nodes(1, 2),
 		spec.Logical(true),
@@ -261,9 +212,7 @@ func ExampleFuncExpr() {
 	reg := registry.New()
 	fe := spec.Function(
 		reg.Get("match"),
-		spec.NodesQuery(
-			spec.Query(false, spec.Child(spec.Name("rating"))),
-		),
+		spec.Query(false, spec.Child(spec.Name("rating"))),
 		spec.Literal("good$"),
 	)
 	fmt.Printf("%v\n", fe)
@@ -275,9 +224,7 @@ func ExampleNotFuncExpr() {
 	reg := registry.New()
 	nf := spec.NotFunction(spec.Function(
 		reg.Get("length"),
-		spec.NodesQuery(
-			spec.Query(false, spec.Child(spec.Index(0))),
-		),
+		spec.Query(false, spec.Child(spec.Index(0))),
 	))
 	fmt.Printf("%v\n", nf)
 	// Output: !length(@[0])
@@ -419,44 +366,47 @@ func ExampleValueType() {
 	// [1 2 false]
 }
 
+// Of the implementations of [PathValue], only [spec.ValueType] and nil
+// can be converted to [spec.ValueType].
 func ExampleValueFrom() {
-	for _, val := range []spec.JSONPathValue{
-		spec.Value("hello"), // converts to value
-		spec.Nodes(1, 2, 3), // does not convert to value
-		spec.Logical(false), // does not convert to value
+	for _, val := range []spec.PathValue{
+		spec.Value("hello"), // no conversion
+		nil,                 // equivalent to no value
 	} {
-		if val.FuncType().ConvertsToValue() {
-			fmt.Printf("val: %v\n", spec.ValueFrom(val))
-		}
+		fmt.Printf("val: %v\n", spec.ValueFrom(val))
 	}
-	// Output: val: hello
+	// Output:
+	// val: hello
+	// val: <nil>
 }
 
+// Of the implementations of [PathValue], only [spec.NodesType] and nil
+// can be converted to [spec.NodesType].
 func ExampleNodesFrom() {
-	for _, val := range []spec.JSONPathValue{
-		spec.Value("hello"), // does not convert to nodes
-		spec.Nodes(1, 2, 3), // converts to nodes
-		spec.Logical(false), // does not convert to nodes
+	for _, val := range []spec.PathValue{
+		spec.Nodes(1, 2, 3), // no conversion
+		nil,                 // converts to empty NodesType
 	} {
-		if val.FuncType().ConvertsToNodes() {
-			fmt.Printf("nodes: %v\n", spec.NodesFrom(val))
-		}
+		fmt.Printf("nodes: %v\n", spec.NodesFrom(val))
 	}
-	// Output: nodes: [1 2 3]
+	// Output:
+	// nodes: [1 2 3]
+	// nodes: []
 }
 
+// Of the implementations of [PathValue], [spec.LogicalType],
+// [spec.NodesType], and nil can be converted to [spec.NodesType].
 func ExampleLogicalFrom() {
-	for _, val := range []spec.JSONPathValue{
-		spec.Value("hello"), // does not convert to logical
+	for _, val := range []spec.PathValue{
 		spec.Nodes(1, 2, 3), // converts to logical (existence)
 		spec.Logical(false), // converts to logical
+		nil,
 	} {
-		if val.FuncType().ConvertsToLogical() {
-			fmt.Printf("logical: %v\n", spec.LogicalFrom(val))
-		}
+		fmt.Printf("logical: %v\n", spec.LogicalFrom(val))
 	}
 	// Output:
 	// logical: true
+	// logical: false
 	// logical: false
 }
 


### PR DESCRIPTION
Replace the `ConvertsTo*()` methods on `FuncType` with `ConvertsTo()` on `FuncExprArg`. This allows more-direct conversion-checking without separately fetching the type.

Remove the `FuncLiteral` and `FuncSingularQuery` variants of `FuncType`. Implementations of `ConvertsTo()` now properly distinguishes between singular and non-singular queries, and the Literal type provided no value over `ValueType`. This restores `FuncLiteral` to just the three variants defined by [RFC 9535 Section 2.4.1]: `ValueType`, `NodesType`, and `LogicalType`.

Improve the docs for `ValueFrom()`, `NodesFrom()`, and `LogicalFrom()` to document whether and how each type is converted, and describe how to avoid panics for invalid conversion by checking `ConvertsTo()` in the function extension validator. Also improve the text of the `panic()` messages, and remove the handling of boolean values from `LogicalFrom()`, as `Logical()` handles that behavior.

Remove `NodesQueryExpr`, a thin wrapper around `PathQuery`, by simply implementing the `FuncExprArg` interface on Query.

Move the `Function` struct to `spec` and name it `FuncExtension`. Have the registry construct it via the `Extension()` constructor, which tightens things up quite a bit. Also move the `Validator` and `Evaluator` aliases to `spec` and use them consistently. Remove the `PathFunction` interface, as it's no longer needed; we instead use `FuncExtension` directly. More consistently refer to them as "function extensions" in the docs, to patch the phrase of the spec.

Rename `JSONPathValue` to `PathValue`, as the `JSON` prefix feels redundant.

  [RFC 9535 Section 2.4.1]: https://www.rfc-editor.org/rfc/rfc9535#name-type-system-for-function-ex