### PR TITLE
Add missing `scanBlankSpace` parsing `&&`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ All notable changes to this project will be documented in this file. It uses the
 *   Upgraded to `golangci-lint` v2.5.0.
 *   Removed unused constant from `parser/lex.go`
 
+### 🐞 Bug Fixes
+
+*   Fixed bug that prevented multiple blank-space delimited ANDed comparison
+    operations from being parsed. For example, `$[@.x=="hi"&&@.y!=3&&@[1]==1]`
+    would parse but `$[@.x == "hi" && @.y !=3 && @[1]==1]` would not. Thanks
+    to @jarangutan for the bug report and @jg-rp for the analysis ([#24]).
+
+  [v0.10.2]: https://github.com/theory/jsonpath/compare/v0.10.1...v0.10.2
+  [#24]: https://github.com/theory/jsonpath/issues/24
+    "theory/jsonpath#24 Filter with 2+ consecutive '&&' operators returns parsing error"
+
 ## [v0.10.1] — 2025-09-16
 
 ### 🐞 Bug Fixes

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -342,6 +342,7 @@ func (p *parser) parseLogicalAndExpr() (spec.LogicalAnd, error) {
 			return nil, err
 		}
 		ors = append(ors, expr)
+		lex.scanBlankSpace()
 	}
 
 	return spec.LogicalAnd(ors), nil

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -384,6 +384,43 @@ func TestParseFilter(t *testing.T) {
 			)),
 		},
 		{
+			test:  "multi_logical_and",
+			query: `(@["x", 1] && $["y"] && @["a"])`,
+			filter: spec.Filter(spec.And(
+				spec.Paren(spec.And(
+					spec.Existence(spec.Query(
+						false,
+						spec.Child(spec.Name("x"), spec.Index(1)),
+					)),
+					spec.Existence(spec.Query(
+						true,
+						spec.Child(spec.Name("y")),
+					)),
+					spec.Existence(spec.Query(
+						false,
+						spec.Child(spec.Name("a")),
+					)),
+				)),
+			)),
+		},
+		{
+			test:  "logical_and_short_name",
+			query: `@.x && @.y`,
+			filter: spec.Filter(spec.And(
+				spec.Existence(spec.Query(false, spec.Child(spec.Name("x")))),
+				spec.Existence(spec.Query(false, spec.Child(spec.Name("y")))),
+			)),
+		},
+		{
+			test:  "multi_logical_and_short_name",
+			query: `@.x && @.y && @.z`,
+			filter: spec.Filter(spec.And(
+				spec.Existence(spec.Query(false, spec.Child(spec.Name("x")))),
+				spec.Existence(spec.Query(false, spec.Child(spec.Name("y")))),
+				spec.Existence(spec.Query(false, spec.Child(spec.Name("z")))),
+			)),
+		},
+		{
 			test:  "paren_logical_or",
 			query: `(@["x", 1] || $["y"])`,
 			filter: spec.Filter(spec.And(
@@ -398,6 +435,23 @@ func TestParseFilter(t *testing.T) {
 					))),
 				)),
 			),
+		},
+		{
+			test:  "logical_or_short_name",
+			query: `@.x && @.y`,
+			filter: spec.Filter(spec.And(
+				spec.Existence(spec.Query(false, spec.Child(spec.Name("x")))),
+				spec.Existence(spec.Query(false, spec.Child(spec.Name("y")))),
+			)),
+		},
+		{
+			test:  "multi_logical_and_short_name",
+			query: `@.x && @.y && @.z`,
+			filter: spec.Filter(spec.And(
+				spec.Existence(spec.Query(false, spec.Child(spec.Name("x")))),
+				spec.Existence(spec.Query(false, spec.Child(spec.Name("y")))),
+				spec.Existence(spec.Query(false, spec.Child(spec.Name("z")))),
+			)),
 		},
 		// NotParenExistExpr
 		{
@@ -668,6 +722,106 @@ func TestParseFilter(t *testing.T) {
 					spec.Literal(int64(42)),
 				),
 			)),
+		},
+		{
+			test:  "and_compare",
+			query: `@.x == "hi" && @.y != 3`,
+			filter: spec.Filter(spec.And(
+				spec.Comparison(
+					spec.SingularQuery(false, spec.Name("x")),
+					spec.EqualTo,
+					spec.Literal("hi"),
+				),
+				spec.Comparison(
+					spec.SingularQuery(false, spec.Name("y")),
+					spec.NotEqualTo,
+					spec.Literal(int64(3)),
+				),
+			)),
+		},
+		{
+			test:  "multi_and_compare",
+			query: `@.x == "hi" && @.y != 3 && $[1] == true`,
+			filter: spec.Filter(spec.And(
+				spec.Comparison(
+					spec.SingularQuery(false, spec.Name("x")),
+					spec.EqualTo,
+					spec.Literal("hi"),
+				),
+				spec.Comparison(
+					spec.SingularQuery(false, spec.Name("y")),
+					spec.NotEqualTo,
+					spec.Literal(int64(3)),
+				),
+				spec.Comparison(
+					spec.SingularQuery(true, spec.Index(1)),
+					spec.EqualTo,
+					spec.Literal(true),
+				),
+			)),
+		},
+		{
+			test:  "multi_and_compare_compact",
+			query: `@.x=="hi"&&@.y!=3&&$[1]==true`,
+			filter: spec.Filter(spec.And(
+				spec.Comparison(
+					spec.SingularQuery(false, spec.Name("x")),
+					spec.EqualTo,
+					spec.Literal("hi"),
+				),
+				spec.Comparison(
+					spec.SingularQuery(false, spec.Name("y")),
+					spec.NotEqualTo,
+					spec.Literal(int64(3)),
+				),
+				spec.Comparison(
+					spec.SingularQuery(true, spec.Index(1)),
+					spec.EqualTo,
+					spec.Literal(true),
+				),
+			)),
+		},
+		{
+			test:  "multi_or_compare",
+			query: `@.x == "hi" || @.y != 3 || $[1] == true`,
+			filter: spec.Filter(
+				spec.And(spec.Comparison(
+					spec.SingularQuery(false, spec.Name("x")),
+					spec.EqualTo,
+					spec.Literal("hi"),
+				)),
+				spec.And(spec.Comparison(
+					spec.SingularQuery(false, spec.Name("y")),
+					spec.NotEqualTo,
+					spec.Literal(int64(3)),
+				)),
+				spec.And(spec.Comparison(
+					spec.SingularQuery(true, spec.Index(1)),
+					spec.EqualTo,
+					spec.Literal(true),
+				)),
+			),
+		},
+		{
+			test:  "multi_or_compare_compact",
+			query: `@.x=="hi"||@.y!=3||$[1]==true`,
+			filter: spec.Filter(
+				spec.And(spec.Comparison(
+					spec.SingularQuery(false, spec.Name("x")),
+					spec.EqualTo,
+					spec.Literal("hi"),
+				)),
+				spec.And(spec.Comparison(
+					spec.SingularQuery(false, spec.Name("y")),
+					spec.NotEqualTo,
+					spec.Literal(int64(3)),
+				)),
+				spec.And(spec.Comparison(
+					spec.SingularQuery(true, spec.Index(1)),
+					spec.EqualTo,
+					spec.Literal(true),
+				)),
+			),
 		},
 		{
 			test:  "invalid_logical_or",


### PR DESCRIPTION
Add `lex.scanBlankSpace()` to the loop in `Parser.parseLogicalAndExpr` so that multiple consecutive `&&` comparison expressions delimited by blank spaces will be properly parsed. Add tests to ensure that the multiple consecutive `||` comparison expressions are also properly parsed. Thanks @jarangutan for the report and @jg-rp for the analysis. Resolves #24.